### PR TITLE
defined and circuit with half-splits, and logarithm bound depth

### DIFF
--- a/AlgoleanTests/CircuitExamples.lean
+++ b/AlgoleanTests/CircuitExamples.lean
@@ -205,18 +205,21 @@ theorem CircAndSimple_depth (n : ℕ) (x : Fin n → Bool) :
         _ = m + 1 + 1 := by ring
 
 
-
+/-- An example "And" circuit with `n` input parameters which are arbitrary circuits,
+splitting the circuit into two halves -/
 def CircAndSplit : (n : ℕ) → (Fin n → FanInTwoCircuit Bool Bool) → FanInTwoCircuit Bool Bool
   | 0,     _  => const true
-  | 1,     x  => x ⟨0, by omega⟩
+  | 1,     x  => x ⟨0, by grind⟩
   | n + 2, x  =>
       let half := (n + 2) / 2
       have h_le : half ≤ n + 2 := Nat.div_le_self _ _
       let x_left  := CircAndSplit half (Fin.take half h_le x)
       let x_right := CircAndSplit ((n + 2) - half)
-        (fun i => x ⟨i.val + half, by omega⟩)
+        (fun i => x ⟨i.val + half, by grind⟩)
       mul x_left x_right
 
+/-- An example "And" circuit with `n` input parameters which are constants,
+ splitting the circuit into two halves -/
 def CircAndSplitSimple : (n : ℕ) → (Fin n → Bool) → FanInTwoCircuit Bool Bool
   | 0,     _  => const true
   | 1,     x  =>  const (x 0)
@@ -225,17 +228,18 @@ def CircAndSplitSimple : (n : ℕ) → (Fin n → Bool) → FanInTwoCircuit Bool
       have h_le : half ≤ n + 2 := Nat.div_le_self _ _
       let x_left  := CircAndSplitSimple half (Fin.take half h_le x)
       let x_right := CircAndSplitSimple ((n + 2) - half)
-        (fun i => x ⟨i.val + half, by omega⟩)
+        (fun i => x ⟨i.val + half, by grind⟩)
       mul x_left x_right
 
-
+/-- The depth of the equally split "And" circuit with `n` input constant parameters
+    has O(log(n)) bound -/
 theorem CircAndSplitSimple_depth (n : ℕ) (x : Fin n → Bool) :
     (CircAndSplitSimple n x).depthOf ≤ Nat.clog 2 n + 1 := by
   induction n using Nat.strong_induction_on with
   | _ n ih =>
     match n with
-    | 0 => simp [CircAndSplitSimple, FanInTwoCircuit.depthOf]
-    | 1 => simp [CircAndSplitSimple, FanInTwoCircuit.depthOf]
+    | 0
+    | 1
     | 2 => simp [CircAndSplitSimple, FanInTwoCircuit.depthOf]
     | n + 2 =>
       let half := (n + 2) / 2
@@ -244,62 +248,59 @@ theorem CircAndSplitSimple_depth (n : ℕ) (x : Fin n → Bool) :
       simp only [FanInTwoCircuit.depthOf]
       -- IH applied to both halves
       have h_left : (CircAndSplitSimple half
-            (Fin.take half (by omega : half ≤ N) x)).depthOf
+            (Fin.take half (by grind : half ≤ N) x)).depthOf
           ≤ Nat.clog 2 half + 1 :=
-        ih half (by omega) _
+        ih half (by grind) _
       have h_right : (CircAndSplitSimple (N - half)
-            (fun i : Fin (N - half) => x ⟨i.val + half, by omega⟩)).depthOf
+            (fun i : Fin (N - half) => x ⟨i.val + half, by grind⟩)).depthOf
           ≤ Nat.clog 2 (N - half) + 1 :=
-        ih (N - half) (by omega) _
+        ih (N - half) (by grind) _
       -- N - half is the ceiling half, which equals (N+1)/2
       have h_right_eq : N - half = (N + 1) / 2 := by
-        simp [half, N]; omega
+        simp [half, N]; grind
       have h_clog : Nat.clog 2 N = Nat.clog 2 ((N + 1) / 2) + 1 := by
-        rw [Nat.clog_of_two_le (by norm_num) (by omega)]
+        rw [Nat.clog_of_two_le (by norm_num) (by grind)]
         grind
       -- Left half ≤ ceil half, so clog is monotone
       have h_left_log : Nat.clog 2 half + 1 ≤ Nat.clog 2 N := by
         rw [h_clog]
         apply Nat.add_le_add_right
         apply Nat.clog_mono_right
-        simp [half, N]; grind
+        simp only [half, N]; grind
       have h_right_log : Nat.clog 2 (N - half) + 1 ≤ Nat.clog 2 N := by
         rw [h_clog, h_right_eq]
       have h_max : 1 +
-            max (CircAndSplitSimple half (Fin.take half (by omega : half ≤ N) x)).depthOf
+            max (CircAndSplitSimple half (Fin.take half (by grind : half ≤ N) x)).depthOf
                 (CircAndSplitSimple (N - half)
-                (fun i : Fin (N - half) => x ⟨i.val + half, by omega⟩)).depthOf
+                (fun i : Fin (N - half) => x ⟨i.val + half, by grind⟩)).depthOf
           ≤ Nat.clog 2 N + 1 := by
-        have := max_le (a := (CircAndSplitSimple half (Fin.take half
-        (by omega : half ≤ N) x)).depthOf)
-                      (b := (CircAndSplitSimple (N - half) (fun i : Fin (N - half)
-                      => x ⟨i.val + half, by omega⟩)).depthOf)
-                      (c := Nat.clog 2 N)
-                      (by grind) (by grind)
         grind
       grind
 
+/-- The size of the equally split "And" circuit with 0 constant parameters
+    is less than or equal 1 -/
 theorem CircAndSplitSimple_size_zero (x : Fin 0 → Bool) :
     (CircAndSplitSimple 0 x).circuitSize ≤ 1 := by
-      simp only [CircAndSplitSimple]
-      simp only [circuitSize, subcircuits.eq_1, insert_empty_eq, Finset.card_singleton,
-        Std.le_refl]
+      simp only [CircAndSplitSimple,circuitSize, subcircuits.eq_1,
+      insert_empty_eq, Finset.card_singleton, Std.le_refl]
 
+/-- The size of the equally split "And" circuit with n > 0 input constant parameters
+    has O(n) bound -/
 theorem CircAndSplitSimple_size_pos (n : ℕ) (hn : 0 < n) (x : Fin n → Bool) :
     (CircAndSplitSimple n x).circuitSize ≤ 2 * n - 1 := by
   induction n using Nat.strong_induction_on with
   | _ n ih =>
     match n with
     | 1 =>
-      simp only [CircAndSplitSimple]
-      simp only [circuitSize, subcircuits.eq_1, insert_empty_eq, Finset.card_singleton,
-        Std.le_refl]
+      simp only [CircAndSplitSimple,circuitSize, subcircuits.eq_1,
+                 insert_empty_eq, Finset.card_singleton,
+                 Std.le_refl]
     | n + 2 =>
       unfold CircAndSplitSimple
       let half := (n + 2) / 2
-      have h_le : half ≤ n + 2 := by omega
+      have h_le : half ≤ n + 2 := by grind
       let x_left := CircAndSplitSimple half (Fin.take half h_le x)
-      let x_right := CircAndSplitSimple (n + 2 - half) (fun i => x ⟨i.val + half, by omega⟩)
+      let x_right := CircAndSplitSimple (n + 2 - half) (fun i => x ⟨i.val + half, by grind⟩)
       change (x_left.mul x_right).circuitSize ≤ 2 * (n + 2) - 1
       have ⟨h_left, h_right⟩ : x_left.circuitSize ≤ 2 * half - 1 ∧
                           x_right.circuitSize ≤ 2 * (n + 2 - half) - 1 := by
@@ -308,12 +309,7 @@ theorem CircAndSplitSimple_size_pos (n : ℕ) (hn : 0 < n) (x : Fin n → Bool) 
       1 + x_left.circuitSize + x_right.circuitSize := by
          grind [circuitSize, subcircuits, Finset.card_insert_le,
          Finset.card_union_le, fanInTwocircuitSize_eq_subcircuits_card]
-      calc (x_left.mul x_right).circuitSize
-          ≤ 1 + x_left.circuitSize + x_right.circuitSize := h_mul_size
-        _ ≤ 1 + (2 * half - 1) + (2 * (n + 2 - half) - 1) := by grind
-        _ = 2 * (n + 2) - 1 := by
-            have : half + (n + 2 - half) = n + 2 := by grind
-            grind
+      grind
 
 
 -- /--

--- a/AlgoleanTests/CircuitExamples.lean
+++ b/AlgoleanTests/CircuitExamples.lean
@@ -279,9 +279,48 @@ theorem CircAndSplitSimple_depth (n : ℕ) (x : Fin n → Bool) :
         grind
       grind
 
+theorem CircAndSplitSimple_size_zero (x : Fin 0 → Bool) :
+    (CircAndSplitSimple 0 x).circuitSize ≤ 1 := by
+      simp only [CircAndSplitSimple]
+      simp only [circuitSize, subcircuits.eq_1, insert_empty_eq, Finset.card_singleton,
+        Std.le_refl]
 
-
-
+theorem CircAndSplitSimple_size_pos (n : ℕ) (hn : 0 < n) (x : Fin n → Bool) :
+    (CircAndSplitSimple n x).circuitSize ≤ 2 * n - 1 := by
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    match n with
+    | 1 =>
+      simp only [CircAndSplitSimple]
+      simp only [circuitSize, subcircuits.eq_1, insert_empty_eq, Finset.card_singleton,
+        Std.le_refl]
+    | n + 2 =>
+      unfold CircAndSplitSimple
+      let half := (n + 2) / 2
+      have h_le : half ≤ n + 2 := by omega
+      let x_left := CircAndSplitSimple half (Fin.take half h_le x)
+      let x_right := CircAndSplitSimple (n + 2 - half) (fun i => x ⟨i.val + half, by omega⟩)
+      change (x_left.mul x_right).circuitSize ≤ 2 * (n + 2) - 1
+      have h_left : x_left.circuitSize ≤ 2 * (half) - 1 := by
+        apply ih
+        · grind
+        · unfold half
+          grind
+      have h_right : x_right.circuitSize ≤ 2 * (n + 2 - half) - 1 := by
+        apply ih
+        · grind
+        · unfold half
+          grind
+      have h_mul_size : (x_left.mul x_right).circuitSize ≤
+      1 + x_left.circuitSize + x_right.circuitSize := by
+         grind [circuitSize, subcircuits, Finset.card_insert_le,
+         Finset.card_union_le, fanInTwocircuitSize_eq_subcircuits_card]
+      calc (x_left.mul x_right).circuitSize
+          ≤ 1 + x_left.circuitSize + x_right.circuitSize := h_mul_size
+        _ ≤ 1 + (2 * half - 1) + (2 * (n + 2 - half) - 1) := by gcongr
+        _ = 2 * (n + 2) - 1 := by
+            have : half + (n + 2 - half) = n + 2 := by omega
+            omega
 
 
 -- /--

--- a/AlgoleanTests/CircuitExamples.lean
+++ b/AlgoleanTests/CircuitExamples.lean
@@ -154,8 +154,12 @@ private lemma tail_max_le_full_max (m : ℕ) (x : Fin (m + 1) → FanInTwoCircui
   have h_mono := Finset.max_mono (tail_image_subset m x)
   cases h_s : (Finset.univ.image (fun i : Fin m => (Fin.tail x i).depthOf)).max <;>
   cases h_t : (Finset.univ.image (fun i : Fin (m + 1) => (x i).depthOf)).max <;>
+<<<<<<< HEAD
     simp_all only [Std.le_refl, bot_le, ge_iff_le, le_bot_iff,
       WithBot.coe_ne_bot, WithBot.coe_le_coe] <;>
+=======
+    simp_all [Std.le_refl,bot_le,ge_iff_le,le_bot_iff,WithBot.coe_ne_bot, WithBot.coe_le_coe] <;>
+>>>>>>> 3a9a339 (depth proof update & build)
     first | exact Nat.zero_le _ | exact h_mono
 
 private lemma head_le_full_max (m : ℕ) (x : Fin (m + 1) → FanInTwoCircuit Bool Bool) :
@@ -203,6 +207,85 @@ theorem CircAndSimple_depth (n : ℕ) (x : Fin n → Bool) :
         1 + (CircAndSimple m (Fin.tail x)).depthOf
         _ ≤ 1 + (m + 1) := by gcongr
         _ = m + 1 + 1 := by ring
+
+
+
+def CircAndSplit : (n : ℕ) → (Fin n → FanInTwoCircuit Bool Bool) → FanInTwoCircuit Bool Bool
+  | 0,     _  => const true
+  | 1,     x  => x ⟨0, by omega⟩
+  | n + 2, x  =>
+      let half := (n + 2) / 2
+      have h_le : half ≤ n + 2 := Nat.div_le_self _ _
+      let x_left  := CircAndSplit half (Fin.take half h_le x)
+      let x_right := CircAndSplit ((n + 2) - half)
+        (fun i => x ⟨i.val + half, by omega⟩)
+      mul x_left x_right
+
+def CircAndSplitSimple : (n : ℕ) → (Fin n → Bool) → FanInTwoCircuit Bool Bool
+  | 0,     _  => const true
+  | 1,     x  =>  const (x 0)
+  | n + 2, x  =>
+      let half := (n + 2) / 2
+      have h_le : half ≤ n + 2 := Nat.div_le_self _ _
+      let x_left  := CircAndSplitSimple half (Fin.take half h_le x)
+      let x_right := CircAndSplitSimple ((n + 2) - half)
+        (fun i => x ⟨i.val + half, by omega⟩)
+      mul x_left x_right
+
+
+theorem CircAndSplitSimple_depth (n : ℕ) (x : Fin n → Bool) :
+    (CircAndSplitSimple n x).depthOf ≤ Nat.clog 2 n + 1 := by
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    match n with
+    | 0 => simp [CircAndSplitSimple, FanInTwoCircuit.depthOf]
+    | 1 => simp [CircAndSplitSimple, FanInTwoCircuit.depthOf]
+    | 2 => simp [CircAndSplitSimple, FanInTwoCircuit.depthOf]
+    | n + 2 =>
+      let half := (n + 2) / 2
+      let N    := n + 2
+      unfold CircAndSplitSimple
+      simp only [FanInTwoCircuit.depthOf]
+      -- IH applied to both halves
+      have h_left : (CircAndSplitSimple half
+            (Fin.take half (by omega : half ≤ N) x)).depthOf
+          ≤ Nat.clog 2 half + 1 :=
+        ih half (by omega) _
+      have h_right : (CircAndSplitSimple (N - half)
+            (fun i : Fin (N - half) => x ⟨i.val + half, by omega⟩)).depthOf
+          ≤ Nat.clog 2 (N - half) + 1 :=
+        ih (N - half) (by omega) _
+      -- N - half is the ceiling half, which equals (N+1)/2
+      have h_right_eq : N - half = (N + 1) / 2 := by
+        simp [half, N]; omega
+      have h_clog : Nat.clog 2 N = Nat.clog 2 ((N + 1) / 2) + 1 := by
+        rw [Nat.clog_of_two_le (by norm_num) (by omega)]
+        grind
+      -- Left half ≤ ceil half, so clog is monotone
+      have h_left_log : Nat.clog 2 half + 1 ≤ Nat.clog 2 N := by
+        rw [h_clog]
+        apply Nat.add_le_add_right
+        apply Nat.clog_mono_right
+        simp [half, N]; grind
+      have h_right_log : Nat.clog 2 (N - half) + 1 ≤ Nat.clog 2 N := by
+        rw [h_clog, h_right_eq]
+      have h_max : 1 +
+            max (CircAndSplitSimple half (Fin.take half (by omega : half ≤ N) x)).depthOf
+                (CircAndSplitSimple (N - half)
+                (fun i : Fin (N - half) => x ⟨i.val + half, by omega⟩)).depthOf
+          ≤ Nat.clog 2 N + 1 := by
+        have := max_le (a := (CircAndSplitSimple half (Fin.take half
+        (by omega : half ≤ N) x)).depthOf)
+                      (b := (CircAndSplitSimple (N - half) (fun i : Fin (N - half)
+                      => x ⟨i.val + half, by omega⟩)).depthOf)
+                      (c := Nat.clog 2 N)
+                      (by grind) (by grind)
+        grind
+      grind
+
+
+
+
 
 
 -- /--

--- a/AlgoleanTests/CircuitExamples.lean
+++ b/AlgoleanTests/CircuitExamples.lean
@@ -154,12 +154,8 @@ private lemma tail_max_le_full_max (m : ℕ) (x : Fin (m + 1) → FanInTwoCircui
   have h_mono := Finset.max_mono (tail_image_subset m x)
   cases h_s : (Finset.univ.image (fun i : Fin m => (Fin.tail x i).depthOf)).max <;>
   cases h_t : (Finset.univ.image (fun i : Fin (m + 1) => (x i).depthOf)).max <;>
-<<<<<<< HEAD
     simp_all only [Std.le_refl, bot_le, ge_iff_le, le_bot_iff,
       WithBot.coe_ne_bot, WithBot.coe_le_coe] <;>
-=======
-    simp_all [Std.le_refl,bot_le,ge_iff_le,le_bot_iff,WithBot.coe_ne_bot, WithBot.coe_le_coe] <;>
->>>>>>> 3a9a339 (depth proof update & build)
     first | exact Nat.zero_le _ | exact h_mono
 
 private lemma head_le_full_max (m : ℕ) (x : Fin (m + 1) → FanInTwoCircuit Bool Bool) :

--- a/AlgoleanTests/CircuitExamples.lean
+++ b/AlgoleanTests/CircuitExamples.lean
@@ -301,16 +301,9 @@ theorem CircAndSplitSimple_size_pos (n : ℕ) (hn : 0 < n) (x : Fin n → Bool) 
       let x_left := CircAndSplitSimple half (Fin.take half h_le x)
       let x_right := CircAndSplitSimple (n + 2 - half) (fun i => x ⟨i.val + half, by omega⟩)
       change (x_left.mul x_right).circuitSize ≤ 2 * (n + 2) - 1
-      have h_left : x_left.circuitSize ≤ 2 * (half) - 1 := by
-        apply ih
-        · grind
-        · unfold half
-          grind
-      have h_right : x_right.circuitSize ≤ 2 * (n + 2 - half) - 1 := by
-        apply ih
-        · grind
-        · unfold half
-          grind
+      have ⟨h_left, h_right⟩ : x_left.circuitSize ≤ 2 * half - 1 ∧
+                          x_right.circuitSize ≤ 2 * (n + 2 - half) - 1 := by
+        constructor <;> (apply ih <;> grind)
       have h_mul_size : (x_left.mul x_right).circuitSize ≤
       1 + x_left.circuitSize + x_right.circuitSize := by
          grind [circuitSize, subcircuits, Finset.card_insert_le,

--- a/AlgoleanTests/CircuitExamples.lean
+++ b/AlgoleanTests/CircuitExamples.lean
@@ -317,10 +317,10 @@ theorem CircAndSplitSimple_size_pos (n : ℕ) (hn : 0 < n) (x : Fin n → Bool) 
          Finset.card_union_le, fanInTwocircuitSize_eq_subcircuits_card]
       calc (x_left.mul x_right).circuitSize
           ≤ 1 + x_left.circuitSize + x_right.circuitSize := h_mul_size
-        _ ≤ 1 + (2 * half - 1) + (2 * (n + 2 - half) - 1) := by gcongr
+        _ ≤ 1 + (2 * half - 1) + (2 * (n + 2 - half) - 1) := by grind
         _ = 2 * (n + 2) - 1 := by
-            have : half + (n + 2 - half) = n + 2 := by omega
-            omega
+            have : half + (n + 2 - half) = n + 2 := by grind
+            grind
 
 
 -- /--

--- a/AlgoleanTests/CircuitExamples.lean
+++ b/AlgoleanTests/CircuitExamples.lean
@@ -205,6 +205,8 @@ theorem CircAndSimple_depth (n : ℕ) (x : Fin n → Bool) :
         _ = m + 1 + 1 := by ring
 
 
+
+
 /-- An example "And" circuit with `n` input parameters which are arbitrary circuits,
 splitting the circuit into two halves -/
 def CircAndSplit : (n : ℕ) → (Fin n → FanInTwoCircuit Bool Bool) → FanInTwoCircuit Bool Bool
@@ -212,8 +214,7 @@ def CircAndSplit : (n : ℕ) → (Fin n → FanInTwoCircuit Bool Bool) → FanIn
   | 1,     x  => x ⟨0, by grind⟩
   | n + 2, x  =>
       let half := (n + 2) / 2
-      have h_le : half ≤ n + 2 := Nat.div_le_self _ _
-      let x_left  := CircAndSplit half (Fin.take half h_le x)
+      let x_left  := CircAndSplit half (Fin.take half (by grind) x)
       let x_right := CircAndSplit ((n + 2) - half)
         (fun i => x ⟨i.val + half, by grind⟩)
       mul x_left x_right
@@ -225,8 +226,7 @@ def CircAndSplitSimple : (n : ℕ) → (Fin n → Bool) → FanInTwoCircuit Bool
   | 1,     x  =>  const (x 0)
   | n + 2, x  =>
       let half := (n + 2) / 2
-      have h_le : half ≤ n + 2 := Nat.div_le_self _ _
-      let x_left  := CircAndSplitSimple half (Fin.take half h_le x)
+      let x_left  := CircAndSplitSimple half (Fin.take half (by grind) x)
       let x_right := CircAndSplitSimple ((n + 2) - half)
         (fun i => x ⟨i.val + half, by grind⟩)
       mul x_left x_right
@@ -246,36 +246,22 @@ theorem CircAndSplitSimple_depth (n : ℕ) (x : Fin n → Bool) :
       let N    := n + 2
       unfold CircAndSplitSimple
       simp only [FanInTwoCircuit.depthOf]
-      -- IH applied to both halves
       have h_left : (CircAndSplitSimple half
-            (Fin.take half (by grind : half ≤ N) x)).depthOf
+            (Fin.take half (by grind) x)).depthOf
           ≤ Nat.clog 2 half + 1 :=
         ih half (by grind) _
       have h_right : (CircAndSplitSimple (N - half)
             (fun i : Fin (N - half) => x ⟨i.val + half, by grind⟩)).depthOf
           ≤ Nat.clog 2 (N - half) + 1 :=
         ih (N - half) (by grind) _
-      -- N - half is the ceiling half, which equals (N+1)/2
-      have h_right_eq : N - half = (N + 1) / 2 := by
-        simp [half, N]; grind
-      have h_clog : Nat.clog 2 N = Nat.clog 2 ((N + 1) / 2) + 1 := by
-        rw [Nat.clog_of_two_le (by norm_num) (by grind)]
-        grind
-      -- Left half ≤ ceil half, so clog is monotone
-      have h_left_log : Nat.clog 2 half + 1 ≤ Nat.clog 2 N := by
-        rw [h_clog]
-        apply Nat.add_le_add_right
-        apply Nat.clog_mono_right
-        simp only [half, N]; grind
-      have h_right_log : Nat.clog 2 (N - half) + 1 ≤ Nat.clog 2 N := by
-        rw [h_clog, h_right_eq]
-      have h_max : 1 +
-            max (CircAndSplitSimple half (Fin.take half (by grind : half ≤ N) x)).depthOf
-                (CircAndSplitSimple (N - half)
-                (fun i : Fin (N - half) => x ⟨i.val + half, by grind⟩)).depthOf
-          ≤ Nat.clog 2 N + 1 := by
-        grind
-      grind
+      rw [Nat.add_comm (Nat.clog 2 (n + 2)) 1]
+      apply Nat.add_le_add_left
+      apply max_le <;>
+        apply Nat.le_trans (by assumption) (by
+          conv_rhs => rw [Nat.clog_of_two_le (by decide) (by grind)]
+          apply Nat.add_le_add_right
+          apply Nat.clog_mono_right
+          grind)
 
 /-- The size of the equally split "And" circuit with 0 constant parameters
     is less than or equal 1 -/
@@ -298,9 +284,9 @@ theorem CircAndSplitSimple_size_pos (n : ℕ) (hn : 0 < n) (x : Fin n → Bool) 
     | n + 2 =>
       unfold CircAndSplitSimple
       let half := (n + 2) / 2
-      have h_le : half ≤ n + 2 := by grind
-      let x_left := CircAndSplitSimple half (Fin.take half h_le x)
-      let x_right := CircAndSplitSimple (n + 2 - half) (fun i => x ⟨i.val + half, by grind⟩)
+      let x_left := CircAndSplitSimple half (Fin.take half (by grind) x)
+      let x_right := CircAndSplitSimple (n + 2 - half)
+        (fun i => x ⟨i.val + half, by grind⟩)
       change (x_left.mul x_right).circuitSize ≤ 2 * (n + 2) - 1
       have ⟨h_left, h_right⟩ : x_left.circuitSize ≤ 2 * half - 1 ∧
                           x_right.circuitSize ≤ 2 * (n + 2 - half) - 1 := by


### PR DESCRIPTION
Added a definition for "And" circuit splitting n inputs into 2 halves, leading to log(n) depth

Theorem added for the depth to be bounded by logarithmic complexity using strong induction manipulating the size of the halves we split to prove our goal.