### PR TITLE
refactor(P/NP): define classes natively via Cslib PolyTimeComputable

### DIFF
--- a/Algolean/Complexity/PolytimeBasicClasses.lean
+++ b/Algolean/Complexity/PolytimeBasicClasses.lean
@@ -1,116 +1,64 @@
 /-
-Copyright (c) 2026 Shreyas Srinivas. All rights reserved.
+Copyright (c) 2026 Tanner Duve. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Shreyas Srinivas
+Authors: Tanner Duve, Shreyas Srinivas
 -/
 
 module
 
-public import Algolean.Complexity.Basic
 public import Cslib.Computability.Machines.SingleTapeTuring.Basic
-public import Algolean.Models.SingleTapeTM
+public import Mathlib.Algebra.Polynomial.Eval.Defs
 
 @[expose] public section
 
 /-!
 # Basic Complexity Classes on Single Tape Turing Machines
 
-We define basic complexity classes `P`, `NP`, `NP-Hard` and `NP-Complete`
-on single tape Turing machines represented by `SingleTapeTM`
-
---
-## Definitions
-
-- `Dir` : A type for directions in which a TM can move.
+We define basic complexity classes `P` and `NP` on single tape Turing
+machines represented by `SingleTapeTM`.
 -/
 
 namespace Algolean
 
 namespace Algorithms
 
-open Cslib Prog Turing
-
-/-! ## Complexity Classes -/
-
-open SingleTapeTM Polynomial
+open Turing SingleTapeTM Polynomial
 
 variable {Symbol : Type} [Inhabited Symbol] [Fintype Symbol]
 
 /-- A language over alphabet `Symbol`. -/
 abbrev Language (Symbol : Type) := List Symbol → Prop
 
-/-- The decision problem for language `L` on input `x`, viewed as a
-`QueryProblem` over `TMQuery tm`. The spec ignores the model
-(there is only one meaningful model per TM). -/
-def TMDecisionProblem (L : Language Symbol) (x : List Symbol)
-    (tm : SingleTapeTM Symbol) : QueryProblem (TMQuery tm) TMCost Bool where
-  spec _ b := (b = true ↔ L x)
-
-/-- A language is in P if there exists a TM, a uniform family of
-programs, and a polynomial such that each program correctly decides
-`L` on input `x` within `p(|x|)` steps under `TMModel tm`. -/
+/-- A language `L` is in `P` if there is a polynomial-time computable
+function `f : List Symbol → List Symbol` and a fixed accept string
+`yes` such that `f x = yes` holds exactly when `L x` holds. -/
 def P (L : Language Symbol) : Prop :=
-  ∃ (tm : SingleTapeTM Symbol)
-    (prog : List Symbol → Prog (TMQuery tm) Bool)
-    (p : Polynomial ℕ),
-    ∀ x, ((prog x).eval (TMModel tm) = true ↔ L x) ∧
-      ((prog x).time (TMModel tm)).steps ≤ p.eval x.length
+  ∃ (f : List Symbol → List Symbol) (yes : List Symbol),
+    Nonempty (PolyTimeComputable f) ∧ ∀ x, f x = yes ↔ L x
 
-/-- A language is in NP if there exists a TM, a uniform verifier
-taking input and certificate separately, and polynomials `p` (time
-bound) and `q` (certificate bound) such that: the verifier runs in
-poly time on all valid-length certificates, and `L x` iff there
-exists a short certificate that the verifier accepts. -/
+/-- A language `L` is in `NP` if there is a polynomial-time computable
+verifier `V : List Symbol → List Symbol`, a fixed accept string `yes`,
+and a polynomial certificate-length bound `q` such that `L x` iff some
+certificate `c` of length at most `q(|x|)` makes `V (x ++ c) = yes`.
+The verifier receives input and certificate concatenated on a single
+tape; the boundary is handled per-language by the verifier. -/
 def NP (L : Language Symbol) : Prop :=
-  ∃ (tm : SingleTapeTM Symbol)
-    (V : List Symbol → List Symbol → Prog (TMQuery tm) Bool)
-    (p q : Polynomial ℕ),
-    (∀ x c, c.length ≤ q.eval x.length →
-      ((V x c).time (TMModel tm)).steps ≤ p.eval x.length) ∧
-    ∀ x, L x ↔ ∃ c : List Symbol, c.length ≤ q.eval x.length ∧
-      (V x c).eval (TMModel tm) = true
+  ∃ (V : List Symbol → List Symbol) (yes : List Symbol) (q : Polynomial ℕ),
+    Nonempty (PolyTimeComputable V) ∧
+    ∀ x, L x ↔ ∃ c : List Symbol,
+      c.length ≤ q.eval x.length ∧ V (x ++ c) = yes
 
-
-
-/-- P is closed under composition via bind. If `P₁` runs within
-`p₁(|x|)` steps and `P₂` runs within `p₂(|x|)` steps on the
-result of `P₁`, then `P₁ >>= P₂` runs within
-`(p₁ + p₂)(|x|)` steps. -/
-theorem P.bind
-    {tm : SingleTapeTM Symbol}
-    {P₁ : List Symbol → Prog (TMQuery tm) α}
-    {P₂ : α → List Symbol → Prog (TMQuery tm) β}
-    {spec₁ : List Symbol → α → Prop}
-    {spec₂ : α → List Symbol → β → Prop}
-    {p₁ p₂ : Polynomial ℕ}
-    (h₁ : ∀ x, spec₁ x ((P₁ x).eval (TMModel tm)) ∧
-      ((P₁ x).time (TMModel tm)).steps ≤ p₁.eval x.length)
-    (h₂ : ∀ x a, spec₁ x a →
-      spec₂ a x ((P₂ a x).eval (TMModel tm)) ∧
-        ((P₂ a x).time (TMModel tm)).steps ≤ p₂.eval x.length) :
-    ∀ x, spec₂ ((P₁ x).eval (TMModel tm)) x
-        (Prog.eval ((P₁ x).bind (P₂ · x)) (TMModel tm)) ∧
-      (Prog.time ((P₁ x).bind (P₂ · x)) (TMModel tm)).steps
-        ≤ (p₁ + p₂).eval x.length := by
-  intro x
-  obtain ⟨hspec₁, htime₁⟩ := h₁ x
-  obtain ⟨hspec₂, htime₂⟩ := h₂ x _ hspec₁
-  simp only [Prog.eval_bind, Prog.time_bind, eval_add]
-  exact ⟨hspec₂, Nat.add_le_add htime₁ htime₂⟩
-
-/-- P ⊆ NP: every language in P is in NP (with trivial certificates).
-The verifier ignores the certificate and runs the decider. -/
+/-- `P ⊆ NP`: every language in `P` is in `NP` with the empty certificate. -/
 theorem NP.ofP {L : Language Symbol} (hP : P L) : NP L := by
-  obtain ⟨tm, P, p, hP⟩ := hP
-  refine ⟨tm, fun x _ => P x, p, 0, ?_, ?_⟩
-  · intro x _ _
-    exact (hP x).2
-  · intro x
-    constructor
-    · intro hLx
-      exact ⟨[], by simp, (hP x).1.mpr hLx⟩
-    · intro ⟨_, _, hVc⟩
-      exact (hP x).1.mp hVc
+  obtain ⟨f, yes, hPTC, hEq⟩ := hP
+  refine ⟨f, yes, 0, hPTC, ?_⟩
+  intro x
+  refine ⟨fun hL => ⟨[], by simp, ?_⟩, ?_⟩
+  · simpa using (hEq x).mpr hL
+  · rintro ⟨c, hlen, hV⟩
+    have hc : c = [] := List.length_eq_zero_iff.mp (Nat.le_zero.mp (by simpa using hlen))
+    subst hc
+    exact (hEq x).mp (by simpa using hV)
 
 end Algorithms
 


### PR DESCRIPTION
## Summary
- Recasts `P` and `NP` directly in terms of `PolyTimeComputable` from Cslib on `SingleTapeTM`, instead of routing through the `Prog` / `TMQuery` / `TMModel` query-model layer.
- Drops `TMDecisionProblem` and `P.bind`; adapts `NP.ofP` to the new definitions.
- Net: `Algolean/Complexity/PolytimeBasicClasses.lean` shrinks from 116 to 64 lines.

## Test plan
- [ ] `lake build` succeeds
- [ ] No downstream files reference the removed `TMDecisionProblem` / `P.bind`