### PR TITLE
refactor(ProgExamples): drop dead `acc` parameter from `linearSearchAux`

### DIFF
--- a/AlgoleanTests/ProgExamples.lean
+++ b/AlgoleanTests/ProgExamples.lean
@@ -108,19 +108,19 @@ def VecSearch.nat [DecidableEq α] : Model (VecSearch α) ℕ where
 
 open VecSearch in
 def linearSearchAux (v : Vector α n)
-    (x : α) (acc : Bool) (index : ℕ) : Prog (VecSearch α) Bool := do
+    (x : α) (index : ℕ) : Prog (VecSearch α) Bool := do
   if h : index ≥ n then
-    return acc
+    return false
   else
     let cmp_res : Bool ← compare v index x
     if cmp_res then
       return true
     else
-      linearSearchAux v x false (index + 1)
+      linearSearchAux v x (index + 1)
 
 open VecSearch in
 def linearSearch (v : Vector α n) (x : α) : Prog (VecSearch α) Bool:=
-  linearSearchAux v x false 0
+  linearSearchAux v x 0
 
 end ProgExamples
 


### PR DESCRIPTION
`acc` was initialized to `false`, only ever passed `false` on recursive miss, and only read at the exhausted-index branch so it could never hold `true`. The `true` result already comes from the in-loop short- circuit. Removing the parameter simplifies the example without changing behavior.