### PR TITLE
Add verified Boyer-Moore majority vote

### DIFF
--- a/Algolean.lean
+++ b/Algolean.lean
@@ -1,6 +1,7 @@
 module  -- shake: keep-all --deprecated_module: ignore
 
 public import Algolean.AddWriter.Basic
+public import Algolean.Algorithms.BoyerMooreMajorityVote
 public import Algolean.Algorithms.Circuits.FanInTwo.LogAnd
 public import Algolean.Algorithms.KMPPatternSearch
 public import Algolean.Algorithms.ListInsertionSort

--- a/Algolean/Algorithms/BoyerMooreMajorityVote.lean
+++ b/Algolean/Algorithms/BoyerMooreMajorityVote.lean
@@ -167,7 +167,7 @@ private lemma VoteState.balance_append_singleton [BEq α] [LawfulBEq α]
     balance a (xs ++ [x]) = balance a xs + if x == a then 1 else -1 := by
   simp only [balance, List.count_append, List.count_cons, List.count_nil,
     List.length_append, List.length_cons, List.length_nil]
-  split <;> omega
+  split <;> lia
 
 private lemma VoteState.score_step [BEq α] [LawfulBEq α]
     (a x : α) (state : VoteState α) :
@@ -179,7 +179,7 @@ private lemma VoteState.score_step [BEq α] [LawfulBEq α]
 private lemma VoteState.balance_pos_of_majority [BEq α] [LawfulBEq α]
     (a : α) (xs : List α) (h : IsMajority a xs) : 0 < balance a xs := by
   simp only [IsMajority, balance] at h ⊢
-  omega
+  lia
 
 private lemma VoteState.candidate_eq_of_score_pos [BEq α] [LawfulBEq α]
     (a : α) (state : VoteState α) (h : 0 < score a state) :
@@ -217,7 +217,7 @@ theorem majorityCandidate_spec [BEq α] [LawfulBEq α] (xs : List α) :
     rw [VoteState.balance_append_singleton]
     refine le_trans ?_ (VoteState.score_step a _ ‹VoteState α›)
     have := ‹∀ a, VoteState.balance a _ ≤ VoteState.score a _› a
-    omega
+    lia
   case vc2.pre => intro a; rfl
   case vc3.post.success =>
     rename_i result hresult
@@ -280,7 +280,7 @@ private lemma voteFoldlM_time [BEq α] (state : VoteState α) (xs : List α) :
       simp only [List.foldlM_cons, Prog.time_bind, List.length_cons]
       have hstep := VoteState.stepM_time state x
       have htail := ih ((VoteState.stepM state x).eval Comparison.natCost)
-      omega
+      lia
 
 private lemma countFoldlM_time [BEq α] (candidate : α) (count : OccurrenceCount α)
     (xs : List α) :
@@ -291,7 +291,7 @@ private lemma countFoldlM_time [BEq α] (candidate : α) (count : OccurrenceCoun
   | nil => simp
   | cons x xs ih =>
       simp [List.foldlM_cons, Prog.time_bind, countStep_time, ih]
-      omega
+      lia
 
 private lemma majorityCandidate_time [BEq α] (xs : List α) :
     (majorityCandidate xs).time Comparison.natCost ≤ xs.length := by
@@ -309,12 +309,12 @@ theorem boyerMooreMajorityVote_time_complexity [BEq α] (xs : List α) :
   split
   · have h := majorityCandidate_time xs
     simp only [Prog.time_pure, add_zero]
-    omega
+    lia
   · rename_i candidate hc
     rw [Prog.time_bind]
     rw [countOccurrences_time]
     have h := majorityCandidate_time xs
-    split <;> simp only [Prog.time_pure, add_zero] <;> omega
+    split <;> simp only [Prog.time_pure, add_zero] <;> lia
 
 end TimeComplexity
 

--- a/Algolean/Algorithms/BoyerMooreMajorityVote.lean
+++ b/Algolean/Algorithms/BoyerMooreMajorityVote.lean
@@ -1,0 +1,352 @@
+/-
+Copyright (c) 2026 Tanner Duve. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tanner Duve
+-/
+
+module
+
+public import Algolean.Models.Comparison
+public import Mathlib.Data.List.Count
+public import Std.Tactic.Do
+
+/-!
+# Boyer--Moore majority vote
+
+This file implements the Boyer--Moore majority-vote algorithm in the `Comparison` query model.
+Both passes use Lean's `for` syntax: the first cancels unequal pairs to select a candidate, and the
+second verifies that the candidate is a strict majority.
+
+## Main definitions
+
+- `IsMajority`: an element occurs in strictly more than half of a list.
+- `boyerMooreMajorityVote`: returns the strict majority element, if one exists.
+
+## Main results
+
+- `boyerMooreMajorityVote_spec`: an `mvcgen`-verified Hoare triple characterizing the result.
+- `boyerMooreMajorityVote_correct`: the algorithm returns `some a` exactly when `a` is a strict
+  majority.
+- `boyerMooreMajorityVote_time_complexity`: the algorithm uses at most `2 * xs.length`
+  comparisons.
+-/
+
+@[expose] public section
+
+namespace Algolean.Algorithms
+
+open Cslib Prog Comparison Std.Do
+
+/-- `a` is a strict majority of `xs` when it occurs more than `xs.length / 2` times. -/
+def IsMajority [BEq α] (a : α) (xs : List α) : Prop :=
+  xs.length < 2 * xs.count a
+
+/-- The cancellation state. `candidate c n` represents a candidate with weight `n + 1`. -/
+inductive VoteState (α : Type*) where
+  | empty
+  | candidate (value : α) (extra : Nat)
+
+namespace VoteState
+
+/-- The candidate retained by a cancellation state. -/
+def candidate? : VoteState α → Option α
+  | .empty => none
+  | .candidate c _ => some c
+
+/-- One pure Boyer--Moore cancellation step. -/
+def step [BEq α] (state : VoteState α) (x : α) : VoteState α :=
+  match state with
+  | .empty => .candidate x 0
+  | .candidate c n =>
+      if c == x then
+        .candidate c (n + 1)
+      else
+        match n with
+        | 0 => .empty
+        | n + 1 => .candidate c n
+
+/-- Signed surplus retained for `a`: positive exactly when the retained candidate is `a`. -/
+def score [BEq α] (a : α) : VoteState α → Int
+  | .empty => 0
+  | .candidate c n =>
+      if c == a then
+        n + 1
+      else
+        -(n + 1)
+
+/-- The occurrence surplus of `a`: occurrences minus non-occurrences. -/
+def balance [BEq α] (a : α) (xs : List α) : Int :=
+  2 * (xs.count a : Int) - xs.length
+
+/-- One monadic Boyer--Moore cancellation step, charging for equality comparisons. -/
+def stepM (state : VoteState α) (x : α) : Prog (Comparison α) (VoteState α) := do
+  match state with
+  | .empty =>
+      return .candidate x 0
+  | .candidate c n =>
+      let same : Bool ← compare c x
+      if same then
+        return .candidate c (n + 1)
+      else
+        match n with
+        | 0 => return .empty
+        | n + 1 => return .candidate c n
+
+end VoteState
+
+/-- Select a majority candidate by cancelling pairs of unequal elements. -/
+def majorityCandidate (xs : List α) : Prog (Comparison α) (Option α) := do
+  let mut state : VoteState α := .empty
+  for x in xs do
+    state ← (state.stepM x : Prog (Comparison α) (VoteState α))
+  return state.candidate?
+
+/--
+Mutable state for the verification pass. The parameter keeps loop invariants universe-polymorphic.
+-/
+structure OccurrenceCount (α : Type*) where
+  value : Nat
+  phantom : Option α
+
+/-- Update an occurrence counter after one comparison. -/
+def countStep (candidate x : α) (count : OccurrenceCount α) :
+    Prog (Comparison α) (OccurrenceCount α) := do
+  let same : Bool ← compare candidate x
+  return if same then ⟨count.value + 1, count.phantom⟩ else count
+
+/-- Run the verification loop, retaining its occurrence-count state. -/
+def countLoop (candidate : α) (xs : List α) : Prog (Comparison α) (OccurrenceCount α) := do
+  let mut count : OccurrenceCount α := ⟨0, none⟩
+  for x in xs do
+    count ← (countStep candidate x count : Prog (Comparison α) (OccurrenceCount α))
+  return count
+
+/-- Count occurrences of `candidate` using comparison queries. -/
+def countOccurrences (candidate : α) (xs : List α) : Prog (Comparison α) Nat := do
+  return (← countLoop candidate xs).value
+
+/--
+Return the strict majority element of `xs`, if it exists, using Boyer--Moore cancellation followed
+by a verification pass.
+-/
+def boyerMooreMajorityVote (xs : List α) : Prog (Comparison α) (Option α) := do
+  match ← majorityCandidate xs with
+  | none =>
+      return none
+  | some candidate =>
+      let occurrences ← countOccurrences candidate xs
+      if xs.length < 2 * occurrences then
+        return some candidate
+      else
+        return none
+
+section Correctness
+
+private theorem VoteState.stepM_eval [BEq α] (state : VoteState α) (x : α) :
+    (state.stepM x).eval Comparison.natCost = state.step x := by
+  cases state with
+  | empty => simp [VoteState.stepM, VoteState.step]
+  | candidate c n =>
+      cases n with
+      | zero =>
+          simp [VoteState.stepM, VoteState.step]
+          split <;> simp_all
+      | succ n =>
+          simp [VoteState.stepM, VoteState.step]
+          split <;> simp_all
+
+private lemma VoteState.balance_append_singleton [BEq α] [LawfulBEq α]
+    (a x : α) (xs : List α) :
+    balance a (xs ++ [x]) = balance a xs + if x == a then 1 else -1 := by
+  simp only [balance, List.count_append, List.count_cons, List.count_nil,
+    List.length_append, List.length_cons, List.length_nil]
+  split <;> omega
+
+private lemma VoteState.score_step [BEq α] [LawfulBEq α]
+    (a x : α) (state : VoteState α) :
+    score a state + (if x == a then 1 else -1) ≤ score a (state.step x) := by
+  cases state with
+  | empty => simp [score, step]
+  | candidate c n =>
+      by_cases hca : c = a
+      · subst c
+        by_cases hax : a = x
+        · subst x; simp [score, step]
+        · have hxa : x ≠ a := fun h => hax h.symm
+          cases n <;> simp [score, step, hax, hxa]
+      · by_cases hxa : x = a
+        · subst x
+          cases n <;> simp [score, step, hca]
+        · by_cases hcx : c = x
+          · subst x; simp [score, step, hca]
+          · cases n with
+            | zero => simp [score, step, hca, hxa, hcx]
+            | succ n => simp [score, step, hca, hxa, hcx]; omega
+
+private lemma VoteState.balance_pos_of_majority [BEq α] [LawfulBEq α]
+    (a : α) (xs : List α) (h : IsMajority a xs) : 0 < balance a xs := by
+  simp only [IsMajority, balance] at h ⊢
+  omega
+
+private lemma VoteState.candidate_eq_of_score_pos [BEq α] [LawfulBEq α]
+    (a : α) (state : VoteState α) (h : 0 < score a state) :
+    state.candidate? = some a := by
+  cases state with
+  | empty => simp [score] at h
+  | candidate c n =>
+      by_cases hca : c = a
+      · subst c; simp [candidate?]
+      · have hn : (0 : Int) ≤ n := by omega
+        simp [score, hca] at h
+        omega
+
+set_option mvcgen.warning false in
+/-- A monadic cancellation step evaluates to the corresponding pure state transition. -/
+theorem VoteState.stepM_spec [BEq α] [LawfulBEq α]
+    (state : VoteState α) (x : α) :
+    ⦃⌜True⌝⦄ state.stepM x ⦃⇓result => ⌜result = state.step x⌝⦄ := by
+  mvcgen [stepM]
+  all_goals simp_all [Comparison.hasModel_model, step]
+
+set_option mvcgen.warning false in
+/-- One verification step increments precisely when the current element equals the candidate. -/
+theorem countStep_spec [BEq α] [LawfulBEq α]
+    (candidate x : α) (count : OccurrenceCount α) :
+    ⦃⌜True⌝⦄ countStep candidate x count
+      ⦃⇓result =>
+        ⌜result = if candidate == x then ⟨count.value + 1, count.phantom⟩ else count⌝⦄ := by
+  mvcgen [countStep]
+
+set_option mvcgen.warning false in
+/-- The first pass retains every strict-majority element as its candidate. -/
+theorem majorityCandidate_spec [BEq α] [LawfulBEq α] (xs : List α) :
+    ⦃⌜True⌝⦄ majorityCandidate xs
+      ⦃⇓candidate => ⌜∀ a, IsMajority a xs → candidate = some a⌝⦄ := by
+  mvcgen [majorityCandidate, VoteState.stepM_spec] invariants
+    · ⇓⟨it, state⟩ =>
+        ⌜∀ a, VoteState.balance a it.prefix ≤ VoteState.score a state⌝
+  case vc1.step.success =>
+    subst_vars
+    intro a
+    rw [VoteState.balance_append_singleton]
+    calc
+      _ ≤ VoteState.score a _ + (if _ == a then 1 else -1) := by
+        simpa only [add_comm] using add_le_add_right
+          (‹∀ a, VoteState.balance a _ ≤ VoteState.score a _› a)
+          (if _ == a then 1 else -1)
+      _ ≤ _ := VoteState.score_step a _ _
+  case vc2.pre => intro a; rfl
+  case vc3.post.success =>
+    rename_i result hresult
+    intro a ha
+    apply VoteState.candidate_eq_of_score_pos a
+    have hle : VoteState.balance a xs ≤ VoteState.score a result := hresult a
+    exact (VoteState.balance_pos_of_majority a xs ha).trans_le hle
+
+set_option mvcgen.warning false in
+/-- The verification loop counts exactly the occurrences of its candidate. -/
+theorem countLoop_spec [BEq α] [LawfulBEq α] (candidate : α) (xs : List α) :
+    ⦃⌜True⌝⦄ countLoop candidate xs
+      ⦃⇓count => ⌜count.value = xs.count candidate⌝⦄ := by
+  mvcgen [countLoop, countStep_spec] invariants
+    · ⇓⟨it, count⟩ => ⌜count.value = it.prefix.count candidate⌝
+  case vc1.step.success pref cur suff hsplit current hcurrent result hresult =>
+    subst result
+    by_cases h : candidate = cur
+    · subst_vars; simp_all [List.count_append]
+    · have h' : cur ≠ candidate := Ne.symm h
+      simp_all [List.count_append]
+
+set_option mvcgen.warning false in
+/-- The verification pass counts exactly the occurrences of its candidate. -/
+theorem countOccurrences_spec [BEq α] [LawfulBEq α] (candidate : α) (xs : List α) :
+    ⦃⌜True⌝⦄ countOccurrences candidate xs
+      ⦃⇓count => ⌜count = xs.count candidate⌝⦄ := by
+  mvcgen [countOccurrences, countLoop_spec]
+
+set_option mvcgen.warning false in
+/--
+Functional correctness as a Hoare triple: the returned element is exactly the strict majority,
+when one exists.
+-/
+theorem boyerMooreMajorityVote_spec [BEq α] [LawfulBEq α] (xs : List α) :
+    ⦃⌜True⌝⦄ boyerMooreMajorityVote xs
+      ⦃⇓result => ⌜∀ a, result = some a ↔ IsMajority a xs⌝⦄ := by
+  mvcgen [boyerMooreMajorityVote, majorityCandidate_spec, countOccurrences_spec]
+  all_goals grind [IsMajority]
+
+/-- Boyer--Moore returns `some a` exactly when `a` is a strict majority of the input. -/
+theorem boyerMooreMajorityVote_correct [BEq α] [LawfulBEq α] (a : α) (xs : List α) :
+    (boyerMooreMajorityVote xs).eval Comparison.natCost = some a ↔ IsMajority a xs := by
+  exact (eval_of_triple (boyerMooreMajorityVote_spec xs) a)
+
+end Correctness
+
+section TimeComplexity
+
+private lemma VoteState.stepM_time [BEq α] (state : VoteState α) (x : α) :
+    (state.stepM x).time Comparison.natCost ≤ 1 := by
+  cases state with
+  | empty => simp [stepM]
+  | candidate c n =>
+      cases n with
+      | zero =>
+          simp [stepM]
+          split <;> simp_all
+      | succ n =>
+          simp [stepM]
+          split <;> simp_all
+
+private lemma countStep_time [BEq α] (candidate x : α) (count : OccurrenceCount α) :
+    (countStep candidate x count).time Comparison.natCost = 1 := by
+  simp [countStep]
+
+private lemma voteFoldlM_time [BEq α] (state : VoteState α) (xs : List α) :
+    (List.foldlM (m := Prog (Comparison α)) (fun state x => state.stepM x) state xs).time
+      Comparison.natCost ≤ xs.length := by
+  induction xs generalizing state with
+  | nil => simp
+  | cons x xs ih =>
+      simp only [List.foldlM_cons, Prog.time_bind, List.length_cons]
+      have hstep := VoteState.stepM_time state x
+      have htail := ih ((state.stepM x).eval Comparison.natCost)
+      omega
+
+private lemma countFoldlM_time [BEq α] (candidate : α) (count : OccurrenceCount α)
+    (xs : List α) :
+    (List.foldlM (m := Prog (Comparison α))
+      (fun count x => countStep candidate x count) count xs).time
+      Comparison.natCost = xs.length := by
+  induction xs generalizing count with
+  | nil => simp
+  | cons x xs ih =>
+      simp only [List.foldlM_cons, Prog.time_bind, List.length_cons]
+      rw [countStep_time, ih]
+      omega
+
+private lemma majorityCandidate_time [BEq α] (xs : List α) :
+    (majorityCandidate xs).time Comparison.natCost ≤ xs.length := by
+  simpa [majorityCandidate] using voteFoldlM_time (.empty : VoteState α) xs
+
+private lemma countOccurrences_time [BEq α] (candidate : α) (xs : List α) :
+    (countOccurrences candidate xs).time Comparison.natCost = xs.length := by
+  simpa [countOccurrences, countLoop] using
+    countFoldlM_time candidate (⟨0, none⟩ : OccurrenceCount α) xs
+
+/-- The two Boyer--Moore passes use at most two equality comparisons per input element. -/
+theorem boyerMooreMajorityVote_time_complexity [BEq α] (xs : List α) :
+    (boyerMooreMajorityVote xs).time Comparison.natCost ≤ 2 * xs.length := by
+  simp only [boyerMooreMajorityVote, Prog.time_bind]
+  split
+  · have h := majorityCandidate_time xs
+    simp only [Prog.time_pure, add_zero]
+    omega
+  · rename_i candidate hc
+    rw [Prog.time_bind]
+    rw [countOccurrences_time]
+    have h := majorityCandidate_time xs
+    split <;> simp only [Prog.time_pure, add_zero] <;> omega
+
+end TimeComplexity
+
+end Algolean.Algorithms

--- a/Algolean/Algorithms/BoyerMooreMajorityVote.lean
+++ b/Algolean/Algorithms/BoyerMooreMajorityVote.lean
@@ -11,9 +11,9 @@ public import Mathlib.Data.List.Count
 public import Std.Tactic.Do
 
 /-!
-# Boyer--Moore majority vote
+# Boyer-Moore majority vote
 
-This file implements the Boyer--Moore majority-vote algorithm in the `Comparison` query model.
+This file implements the Boyer-Moore majority-vote algorithm in the `Comparison` query model.
 
 ## Algorithm
 
@@ -57,34 +57,30 @@ open Cslib Prog Comparison Std.Do
 def IsMajority [BEq α] (a : α) (xs : List α) : Prop :=
   xs.length < 2 * xs.count a
 
-/-- The cancellation state. `candidate c n` represents a candidate with weight `n + 1`. -/
-inductive VoteState (α : Type*) where
-  | empty
-  | candidate (value : α) (extra : Nat)
+/--
+The cancellation state. `none` means no current candidate; `some (c, n)` represents candidate `c`
+with weight `n + 1`.
+-/
+abbrev VoteState (α : Type*) := Option (α × Nat)
 
 namespace VoteState
 
-/-- The candidate retained by a cancellation state. -/
-def candidate? : VoteState α → Option α
-  | .empty => none
-  | .candidate c _ => some c
-
-/-- One pure Boyer--Moore cancellation step. -/
+/-- One pure Boyer-Moore cancellation step. -/
 def step [BEq α] (state : VoteState α) (x : α) : VoteState α :=
   match state with
-  | .empty => .candidate x 0
-  | .candidate c n =>
+  | none => some (x, 0)
+  | some (c, n) =>
       if c == x then
-        .candidate c (n + 1)
+        some (c, n + 1)
       else
         match n with
-        | 0 => .empty
-        | n + 1 => .candidate c n
+        | 0 => none
+        | n + 1 => some (c, n)
 
 /-- Signed surplus retained for `a`: positive exactly when the retained candidate is `a`. -/
 def score [BEq α] (a : α) : VoteState α → Int
-  | .empty => 0
-  | .candidate c n =>
+  | none => 0
+  | some (c, n) =>
       if c == a then
         n + 1
       else
@@ -94,34 +90,36 @@ def score [BEq α] (a : α) : VoteState α → Int
 def balance [BEq α] (a : α) (xs : List α) : Int :=
   2 * (xs.count a : Int) - xs.length
 
-/-- One monadic Boyer--Moore cancellation step, charging for equality comparisons. -/
+/-- One monadic Boyer-Moore cancellation step, charging for equality comparisons. -/
 def stepM (state : VoteState α) (x : α) : Prog (Comparison α) (VoteState α) := do
   match state with
-  | .empty =>
-      return .candidate x 0
-  | .candidate c n =>
+  | none =>
+      return some (x, 0)
+  | some (c, n) =>
       let same : Bool ← compare c x
       if same then
-        return .candidate c (n + 1)
+        return some (c, n + 1)
       else
         match n with
-        | 0 => return .empty
-        | n + 1 => return .candidate c n
+        | 0 => return none
+        | n + 1 => return some (c, n)
 
 end VoteState
 
 /-- Select a majority candidate by cancelling pairs of unequal elements. -/
 def majorityCandidate (xs : List α) : Prog (Comparison α) (Option α) := do
-  let mut state : VoteState α := .empty
+  let mut state : VoteState α := none
   for x in xs do
-    state ← (state.stepM x : Prog (Comparison α) (VoteState α))
-  return state.candidate?
+    state ← (VoteState.stepM state x : Prog (Comparison α) (VoteState α))
+  return state.map Prod.fst
 
 /--
 Mutable state for the verification pass. The parameter keeps loop invariants universe-polymorphic.
 -/
 structure OccurrenceCount (α : Type*) where
+  /-- Occurrences of the candidate counted so far. -/
   value : Nat
+  /-- Unused; its type mentions `α` to keep the loop invariant universe-polymorphic. -/
   phantom : Option α
 
 /-- Update an occurrence counter after one comparison. -/
@@ -142,7 +140,7 @@ def countOccurrences (candidate : α) (xs : List α) : Prog (Comparison α) Nat 
   return (← countLoop candidate xs).value
 
 /--
-Return the strict majority element of `xs`, if it exists, using Boyer--Moore cancellation followed
+Return the strict majority element of `xs`, if it exists, using Boyer-Moore cancellation followed
 by a verification pass.
 -/
 def boyerMooreMajorityVote (xs : List α) : Prog (Comparison α) (Option α) := do
@@ -159,11 +157,10 @@ def boyerMooreMajorityVote (xs : List α) : Prog (Comparison α) (Option α) := 
 section Correctness
 
 private theorem VoteState.stepM_eval [BEq α] (state : VoteState α) (x : α) :
-    (state.stepM x).eval Comparison.natCost = state.step x := by
-  cases state with
-  | empty => simp [VoteState.stepM, VoteState.step]
-  | candidate c n =>
-      cases n <;> simp [VoteState.stepM, VoteState.step] <;> split <;> simp_all
+    (VoteState.stepM state x).eval Comparison.natCost = VoteState.step state x := by
+  rcases state with _ | ⟨c, n⟩
+  · simp [VoteState.stepM, VoteState.step]
+  · cases n <;> simp [VoteState.stepM, VoteState.step] <;> split <;> simp_all
 
 private lemma VoteState.balance_append_singleton [BEq α] [LawfulBEq α]
     (a x : α) (xs : List α) :
@@ -174,10 +171,10 @@ private lemma VoteState.balance_append_singleton [BEq α] [LawfulBEq α]
 
 private lemma VoteState.score_step [BEq α] [LawfulBEq α]
     (a x : α) (state : VoteState α) :
-    score a state + (if x == a then 1 else -1) ≤ score a (state.step x) := by
-  cases state with
-  | empty => simp [score, step]
-  | candidate c n => cases n <;> simp [score, step] <;> grind
+    score a state + (if x == a then 1 else -1) ≤ score a (VoteState.step state x) := by
+  rcases state with _ | ⟨c, n⟩
+  · simp [score, step]
+  · cases n <;> simp [score, step] <;> grind
 
 private lemma VoteState.balance_pos_of_majority [BEq α] [LawfulBEq α]
     (a : α) (xs : List α) (h : IsMajority a xs) : 0 < balance a xs := by
@@ -186,14 +183,14 @@ private lemma VoteState.balance_pos_of_majority [BEq α] [LawfulBEq α]
 
 private lemma VoteState.candidate_eq_of_score_pos [BEq α] [LawfulBEq α]
     (a : α) (state : VoteState α) (h : 0 < score a state) :
-    state.candidate? = some a := by
-  cases state <;> grind [score, candidate?]
+    state.map Prod.fst = some a := by
+  rcases state with _ | ⟨c, n⟩ <;> grind [score]
 
 set_option mvcgen.warning false in
 /-- A monadic cancellation step evaluates to the corresponding pure state transition. -/
 theorem VoteState.stepM_spec [BEq α] [LawfulBEq α]
     (state : VoteState α) (x : α) :
-    ⦃⌜True⌝⦄ state.stepM x ⦃⇓result => ⌜result = state.step x⌝⦄ := by
+    ⦃⌜True⌝⦄ VoteState.stepM state x ⦃⇓result => ⌜result = VoteState.step state x⌝⦄ := by
   mvcgen [stepM]
   all_goals simp_all [Comparison.hasModel_model, step]
 
@@ -255,7 +252,7 @@ theorem boyerMooreMajorityVote_spec [BEq α] [LawfulBEq α] (xs : List α) :
   mvcgen [boyerMooreMajorityVote, majorityCandidate_spec, countOccurrences_spec]
   all_goals grind [IsMajority]
 
-/-- Boyer--Moore returns `some a` exactly when `a` is a strict majority of the input. -/
+/-- Boyer-Moore returns `some a` exactly when `a` is a strict majority of the input. -/
 theorem boyerMooreMajorityVote_correct [BEq α] [LawfulBEq α] (a : α) (xs : List α) :
     (boyerMooreMajorityVote xs).eval Comparison.natCost = some a ↔ IsMajority a xs := by
   exact (eval_of_triple (boyerMooreMajorityVote_spec xs) a)
@@ -265,24 +262,24 @@ end Correctness
 section TimeComplexity
 
 private lemma VoteState.stepM_time [BEq α] (state : VoteState α) (x : α) :
-    (state.stepM x).time Comparison.natCost ≤ 1 := by
-  cases state with
-  | empty => simp [stepM]
-  | candidate c n => cases n <;> simp [stepM] <;> split <;> simp_all
+    (VoteState.stepM state x).time Comparison.natCost ≤ 1 := by
+  rcases state with _ | ⟨c, n⟩
+  · simp [stepM]
+  · cases n <;> simp [stepM] <;> split <;> simp_all
 
 private lemma countStep_time [BEq α] (candidate x : α) (count : OccurrenceCount α) :
     (countStep candidate x count).time Comparison.natCost = 1 := by
   simp [countStep]
 
 private lemma voteFoldlM_time [BEq α] (state : VoteState α) (xs : List α) :
-    (List.foldlM (m := Prog (Comparison α)) (fun state x => state.stepM x) state xs).time
+    (List.foldlM (m := Prog (Comparison α)) (fun state x => VoteState.stepM state x) state xs).time
       Comparison.natCost ≤ xs.length := by
   induction xs generalizing state with
   | nil => simp
   | cons x xs ih =>
       simp only [List.foldlM_cons, Prog.time_bind, List.length_cons]
       have hstep := VoteState.stepM_time state x
-      have htail := ih ((state.stepM x).eval Comparison.natCost)
+      have htail := ih ((VoteState.stepM state x).eval Comparison.natCost)
       omega
 
 private lemma countFoldlM_time [BEq α] (candidate : α) (count : OccurrenceCount α)
@@ -298,14 +295,14 @@ private lemma countFoldlM_time [BEq α] (candidate : α) (count : OccurrenceCoun
 
 private lemma majorityCandidate_time [BEq α] (xs : List α) :
     (majorityCandidate xs).time Comparison.natCost ≤ xs.length := by
-  simpa [majorityCandidate] using voteFoldlM_time (.empty : VoteState α) xs
+  simpa [majorityCandidate] using voteFoldlM_time (none : VoteState α) xs
 
 private lemma countOccurrences_time [BEq α] (candidate : α) (xs : List α) :
     (countOccurrences candidate xs).time Comparison.natCost = xs.length := by
   simpa [countOccurrences, countLoop] using
     countFoldlM_time candidate (⟨0, none⟩ : OccurrenceCount α) xs
 
-/-- The two Boyer--Moore passes use at most two equality comparisons per input element. -/
+/-- The two Boyer-Moore passes use at most two equality comparisons per input element. -/
 theorem boyerMooreMajorityVote_time_complexity [BEq α] (xs : List α) :
     (boyerMooreMajorityVote xs).time Comparison.natCost ≤ 2 * xs.length := by
   simp only [boyerMooreMajorityVote, Prog.time_bind]

--- a/Algolean/Algorithms/BoyerMooreMajorityVote.lean
+++ b/Algolean/Algorithms/BoyerMooreMajorityVote.lean
@@ -14,8 +14,24 @@ public import Std.Tactic.Do
 # Boyer--Moore majority vote
 
 This file implements the Boyer--Moore majority-vote algorithm in the `Comparison` query model.
-Both passes use Lean's `for` syntax: the first cancels unequal pairs to select a candidate, and the
-second verifies that the candidate is a strict majority.
+
+## Algorithm
+
+An element is a strict majority of a list when it occurs in strictly more than half of the
+positions. The algorithm finds it, if it exists, in two passes that use only equality comparisons.
+
+The first pass selects a candidate by cancellation. It maintains a current candidate together with a
+weight. Starting from no candidate, it processes each element `x` as follows. If there is no current
+candidate, `x` becomes the candidate with weight one. If `x` equals the current candidate, the
+weight increases by one. If `x` differs from the current candidate, the weight decreases by one, and
+the candidate is discarded once the weight reaches zero. Each differing element thus cancels one
+unit of the candidate's weight. A strict majority element occurs more often than all other elements
+combined, so it survives every cancellation and is the candidate retained at the end.
+
+Cancellation only guarantees that if a strict majority exists it is the retained candidate. The
+retained candidate need not itself be a majority when no majority exists. The second pass therefore
+counts the actual occurrences of the candidate and returns it only when that count exceeds half the
+length, and returns `none` otherwise.
 
 ## Main definitions
 
@@ -202,19 +218,15 @@ theorem majorityCandidate_spec [BEq α] [LawfulBEq α] (xs : List α) :
     subst_vars
     intro a
     rw [VoteState.balance_append_singleton]
-    calc
-      _ ≤ VoteState.score a _ + (if _ == a then 1 else -1) := by
-        simpa only [add_comm] using add_le_add_right
-          (‹∀ a, VoteState.balance a _ ≤ VoteState.score a _› a)
-          (if _ == a then 1 else -1)
-      _ ≤ _ := VoteState.score_step a _ _
+    refine le_trans ?_ (VoteState.score_step a _ ‹VoteState α›)
+    have := ‹∀ a, VoteState.balance a _ ≤ VoteState.score a _› a
+    omega
   case vc2.pre => intro a; rfl
   case vc3.post.success =>
     rename_i result hresult
     intro a ha
-    apply VoteState.candidate_eq_of_score_pos a
-    have hle : VoteState.balance a xs ≤ VoteState.score a result := hresult a
-    exact (VoteState.balance_pos_of_majority a xs ha).trans_le hle
+    exact VoteState.candidate_eq_of_score_pos a _
+      ((VoteState.balance_pos_of_majority a xs ha).trans_le (hresult a))
 
 set_option mvcgen.warning false in
 /-- The verification loop counts exactly the occurrences of its candidate. -/

--- a/Algolean/Algorithms/BoyerMooreMajorityVote.lean
+++ b/Algolean/Algorithms/BoyerMooreMajorityVote.lean
@@ -147,13 +147,7 @@ private theorem VoteState.stepM_eval [BEq α] (state : VoteState α) (x : α) :
   cases state with
   | empty => simp [VoteState.stepM, VoteState.step]
   | candidate c n =>
-      cases n with
-      | zero =>
-          simp [VoteState.stepM, VoteState.step]
-          split <;> simp_all
-      | succ n =>
-          simp [VoteState.stepM, VoteState.step]
-          split <;> simp_all
+      cases n <;> simp [VoteState.stepM, VoteState.step] <;> split <;> simp_all
 
 private lemma VoteState.balance_append_singleton [BEq α] [LawfulBEq α]
     (a x : α) (xs : List α) :
@@ -167,21 +161,7 @@ private lemma VoteState.score_step [BEq α] [LawfulBEq α]
     score a state + (if x == a then 1 else -1) ≤ score a (state.step x) := by
   cases state with
   | empty => simp [score, step]
-  | candidate c n =>
-      by_cases hca : c = a
-      · subst c
-        by_cases hax : a = x
-        · subst x; simp [score, step]
-        · have hxa : x ≠ a := fun h => hax h.symm
-          cases n <;> simp [score, step, hax, hxa]
-      · by_cases hxa : x = a
-        · subst x
-          cases n <;> simp [score, step, hca]
-        · by_cases hcx : c = x
-          · subst x; simp [score, step, hca]
-          · cases n with
-            | zero => simp [score, step, hca, hxa, hcx]
-            | succ n => simp [score, step, hca, hxa, hcx]; omega
+  | candidate c n => cases n <;> simp [score, step] <;> grind
 
 private lemma VoteState.balance_pos_of_majority [BEq α] [LawfulBEq α]
     (a : α) (xs : List α) (h : IsMajority a xs) : 0 < balance a xs := by
@@ -191,14 +171,7 @@ private lemma VoteState.balance_pos_of_majority [BEq α] [LawfulBEq α]
 private lemma VoteState.candidate_eq_of_score_pos [BEq α] [LawfulBEq α]
     (a : α) (state : VoteState α) (h : 0 < score a state) :
     state.candidate? = some a := by
-  cases state with
-  | empty => simp [score] at h
-  | candidate c n =>
-      by_cases hca : c = a
-      · subst c; simp [candidate?]
-      · have hn : (0 : Int) ≤ n := by omega
-        simp [score, hca] at h
-        omega
+  cases state <;> grind [score, candidate?]
 
 set_option mvcgen.warning false in
 /-- A monadic cancellation step evaluates to the corresponding pure state transition. -/
@@ -250,12 +223,7 @@ theorem countLoop_spec [BEq α] [LawfulBEq α] (candidate : α) (xs : List α) :
       ⦃⇓count => ⌜count.value = xs.count candidate⌝⦄ := by
   mvcgen [countLoop, countStep_spec] invariants
     · ⇓⟨it, count⟩ => ⌜count.value = it.prefix.count candidate⌝
-  case vc1.step.success pref cur suff hsplit current hcurrent result hresult =>
-    subst result
-    by_cases h : candidate = cur
-    · subst_vars; simp_all [List.count_append]
-    · have h' : cur ≠ candidate := Ne.symm h
-      simp_all [List.count_append]
+  all_goals grind
 
 set_option mvcgen.warning false in
 /-- The verification pass counts exactly the occurrences of its candidate. -/
@@ -288,14 +256,7 @@ private lemma VoteState.stepM_time [BEq α] (state : VoteState α) (x : α) :
     (state.stepM x).time Comparison.natCost ≤ 1 := by
   cases state with
   | empty => simp [stepM]
-  | candidate c n =>
-      cases n with
-      | zero =>
-          simp [stepM]
-          split <;> simp_all
-      | succ n =>
-          simp [stepM]
-          split <;> simp_all
+  | candidate c n => cases n <;> simp [stepM] <;> split <;> simp_all
 
 private lemma countStep_time [BEq α] (candidate x : α) (count : OccurrenceCount α) :
     (countStep candidate x count).time Comparison.natCost = 1 := by
@@ -320,8 +281,7 @@ private lemma countFoldlM_time [BEq α] (candidate : α) (count : OccurrenceCoun
   induction xs generalizing count with
   | nil => simp
   | cons x xs ih =>
-      simp only [List.foldlM_cons, Prog.time_bind, List.length_cons]
-      rw [countStep_time, ih]
+      simp [List.foldlM_cons, Prog.time_bind, countStep_time, ih]
       omega
 
 private lemma majorityCandidate_time [BEq α] (xs : List α) :

--- a/Algolean/Models/Comparison.lean
+++ b/Algolean/Models/Comparison.lean
@@ -46,6 +46,14 @@ def Comparison.natCost [BEq α] : Model (Comparison α) ℕ where
     | .compare x y => x == y
   cost _ := 1
 
+/-- Register `natCost` as the default comparison model for weakest-precondition proofs. -/
+instance [BEq α] : HasModel (Comparison α) ℕ where
+  model := Comparison.natCost
+
+/-- The default comparison model unfolds to `natCost`. -/
+@[simp] theorem Comparison.hasModel_model [BEq α] :
+    (HasModel.model : Model (Comparison α) ℕ) = Comparison.natCost := rfl
+
 end Algorithms
 
 end Algolean


### PR DESCRIPTION
Implements the Boyer--Moore majority-vote algorithm in the `Comparison` query model, with correctness and time-complexity proofs.

## What this adds

- `boyerMooreMajorityVote`: returns the strict majority element of a list if one exists, using two passes of equality comparisons (candidate selection by cancellation, then a verification/count pass).
- `IsMajority` and the `VoteState` cancellation state, with pure and monadic (`Comparison`-query) step functions.

## Main results

- `boyerMooreMajorityVote_spec`: an `mvcgen`-verified Hoare triple characterizing the result.
- `boyerMooreMajorityVote_correct`: the algorithm returns `some a` exactly when `a` is a strict majority.
- `boyerMooreMajorityVote_time_complexity`: at most `2 * xs.length` comparisons.

The module header includes a precise prose description of both passes, including why a strict majority survives all cancellations and why the second verification pass is needed.