### PR TITLE
Add monadic query models

### DIFF
--- a/Algolean.lean
+++ b/Algolean.lean
@@ -17,6 +17,7 @@ public import Algolean.Complexity.PolytimeBasicClasses
 public import Algolean.FreeWP.Effects
 public import Algolean.FreeWP.WP
 public import Algolean.LowerBounds.ComparisonSort
+public import Algolean.ModelM
 public import Algolean.Models.Circuits
 public import Algolean.Models.Comparison
 public import Algolean.Models.FanInTwoCircuits
@@ -33,4 +34,3 @@ public import Algolean.Models.RobertsonWebb
 public import Algolean.Models.SingleTapeTM
 public import Algolean.QueryComposition
 public import Algolean.QueryModel
-public import Algolean.ModelM

--- a/Algolean.lean
+++ b/Algolean.lean
@@ -1,6 +1,7 @@
 module  -- shake: keep-all --deprecated_module: ignore
 
 public import Algolean.AddWriter.Basic
+public import Algolean.AddWriter.Transformer
 public import Algolean.Algorithms.BoyerMooreMajorityVote
 public import Algolean.Algorithms.Circuits.FanInTwo.LogAnd
 public import Algolean.Algorithms.KMPPatternSearch
@@ -32,3 +33,4 @@ public import Algolean.Models.RobertsonWebb
 public import Algolean.Models.SingleTapeTM
 public import Algolean.QueryComposition
 public import Algolean.QueryModel
+public import Algolean.ModelM

--- a/Algolean/AddWriter/Transformer.lean
+++ b/Algolean/AddWriter/Transformer.lean
@@ -13,12 +13,16 @@ public import Algolean.AddWriter.Basic
 
 `AddWriterT Cost m α` is an `m` computation returning an `α` together with an accumulated cost.
 Keeping `m` outside the pair preserves the correlation between effect branches, results, and costs.
+
+Algolean uses this transformer in `Prog.runM` to evaluate a query program in its model's monad
+while accumulating the costs assigned to its queries.
 -/
 
 @[expose] public section
 
 namespace Algolean
 
+/-- The additive writer transformer over `m`, with costs in `Cost`. -/
 def AddWriterT (Cost : Type u) (m : Type u → Type v) (α : Type u) : Type v :=
   m (AddWriter Cost α)
 
@@ -26,20 +30,29 @@ namespace AddWriterT
 
 variable {Cost : Type u} {m : Type u → Type v} {α β : Type u}
 
+/-- Construct an `AddWriterT` computation from its representation. -/
 @[inline] def mk (x : m (AddWriter Cost α)) : AddWriterT Cost m α := x
+
+/-- Return the underlying computation. -/
 @[inline] def run (x : AddWriterT Cost m α) : m (AddWriter Cost α) := x
 
 @[simp] theorem run_mk (x : m (AddWriter Cost α)) : (mk x).run = x := rfl
 @[simp] theorem mk_run (x : AddWriterT Cost m α) : mk x.run = x := rfl
 
+/-- Project the return value into `m`. -/
 def value [Functor m] (x : AddWriterT Cost m α) : m α :=
   (·.ret) <$> x.run
 
+/-- Project the accumulated cost into `m`. -/
 def cost [Functor m] (x : AddWriterT Cost m α) : m Cost :=
   (·.tell) <$> x.run
 
+/-- Lift a computation in `m` with cost zero. -/
 def lift [Functor m] [Zero Cost] (x : m α) : AddWriterT Cost m α :=
   mk ((⟨·, 0⟩) <$> x)
+
+instance [Functor m] [Zero Cost] : MonadLift m (AddWriterT Cost m) where
+  monadLift := lift
 
 instance [Functor m] : Functor (AddWriterT Cost m) where
   map f x := mk ((fun a => ⟨f a.ret, a.tell⟩) <$> x.run)
@@ -63,6 +76,9 @@ instance [Monad m] [AddZero Cost] : Monad (AddWriterT Cost m) where
 
 @[simp] theorem run_pure [Monad m] [Zero Cost] (a : α) :
     (pure a : AddWriterT Cost m α).run = pure (pure a) := rfl
+
+@[simp] theorem run_liftM [Functor m] [Zero Cost] (x : m α) :
+    (liftM x : AddWriterT Cost m α).run = ((fun a => ⟨a, 0⟩) <$> x) := rfl
 
 @[simp] theorem run_bind [Monad m] [Add Cost]
     (x : AddWriterT Cost m α) (f : α → AddWriterT Cost m β) :
@@ -104,14 +120,15 @@ theorem cost_bind [Monad m] [LawfulMonad m] [Add Cost]
       pure (a.tell + b.tell)) := by
   simp only [cost, run_bind, map_bind, map_pure]
 
-theorem run_injective {x y : AddWriterT Cost m α} (h : x.run = y.run) : x = y := h
+@[ext] protected theorem ext
+    (x y : AddWriterT Cost m α) (h : x.run = y.run) : x = y := h
 
 instance [Monad m] [LawfulMonad m] [AddMonoid Cost] : LawfulMonad (AddWriterT Cost m) :=
   LawfulMonad.mk'
-    (id_map := fun x => run_injective (by simp))
-    (pure_bind := fun a f => run_injective (by simp))
-    (bind_assoc := fun x f g => run_injective (by simp [bind_assoc, add_assoc]))
-    (bind_pure_comp := fun f x => run_injective (by simp [add_zero]))
+    (id_map := fun x => AddWriterT.ext _ _ (by simp))
+    (pure_bind := fun a f => AddWriterT.ext _ _ (by simp))
+    (bind_assoc := fun x f g => AddWriterT.ext _ _ (by simp [bind_assoc, add_assoc]))
+    (bind_pure_comp := fun f x => AddWriterT.ext _ _ (by simp [add_zero]))
 
 end AddWriterT
 end Algolean

--- a/Algolean/AddWriter/Transformer.lean
+++ b/Algolean/AddWriter/Transformer.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2026 Tanner Duve. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tanner Duve
+-/
+
+module
+
+public import Algolean.AddWriter.Basic
+
+/-!
+# Additive writer monad transformer
+
+`AddWriterT Cost m α` is an `m` computation returning an `α` together with an accumulated cost.
+Keeping `m` outside the pair preserves the correlation between effect branches, results, and costs.
+-/
+
+@[expose] public section
+
+namespace Algolean
+
+def AddWriterT (Cost : Type u) (m : Type u → Type v) (α : Type u) : Type v :=
+  m (AddWriter Cost α)
+
+namespace AddWriterT
+
+variable {Cost : Type u} {m : Type u → Type v} {α β : Type u}
+
+@[inline] def mk (x : m (AddWriter Cost α)) : AddWriterT Cost m α := x
+@[inline] def run (x : AddWriterT Cost m α) : m (AddWriter Cost α) := x
+
+@[simp] theorem run_mk (x : m (AddWriter Cost α)) : (mk x).run = x := rfl
+@[simp] theorem mk_run (x : AddWriterT Cost m α) : mk x.run = x := rfl
+
+def value [Functor m] (x : AddWriterT Cost m α) : m α :=
+  (·.ret) <$> x.run
+
+def cost [Functor m] (x : AddWriterT Cost m α) : m Cost :=
+  (·.tell) <$> x.run
+
+def lift [Functor m] [Zero Cost] (x : m α) : AddWriterT Cost m α :=
+  mk ((⟨·, 0⟩) <$> x)
+
+instance [Functor m] : Functor (AddWriterT Cost m) where
+  map f x := mk ((fun a => ⟨f a.ret, a.tell⟩) <$> x.run)
+
+instance [Monad m] [Zero Cost] : Pure (AddWriterT Cost m) where
+  pure a := mk (pure (pure a))
+
+instance [Monad m] [Add Cost] : Bind (AddWriterT Cost m) where
+  bind x f := mk do
+    let a ← x.run
+    let b ← (f a.ret).run
+    pure ⟨b.ret, a.tell + b.tell⟩
+
+instance [Monad m] [AddZero Cost] : Monad (AddWriterT Cost m) where
+  pure := Pure.pure
+  bind := Bind.bind
+  map := Functor.map
+
+@[simp] theorem run_map [Functor m] (f : α → β) (x : AddWriterT Cost m α) :
+    (f <$> x).run = ((fun a => (⟨f a.ret, a.tell⟩ : AddWriter Cost β)) <$> x.run) := rfl
+
+@[simp] theorem run_pure [Monad m] [Zero Cost] (a : α) :
+    (pure a : AddWriterT Cost m α).run = pure (pure a) := rfl
+
+@[simp] theorem run_bind [Monad m] [Add Cost]
+    (x : AddWriterT Cost m α) (f : α → AddWriterT Cost m β) :
+    (x >>= f).run = (do
+      let a ← x.run
+      let b ← (f a.ret).run
+      pure ⟨b.ret, a.tell + b.tell⟩) := rfl
+
+@[simp] theorem value_pure [Monad m] [LawfulMonad m] [Zero Cost] (a : α) :
+    (pure a : AddWriterT Cost m α).value = (pure a : m α) := by
+  simp [value]
+
+@[simp] theorem cost_pure [Monad m] [LawfulMonad m] [Zero Cost] (a : α) :
+    (pure a : AddWriterT Cost m α).cost = (pure 0 : m Cost) := by
+  simp [cost]
+
+@[simp] theorem value_map [Functor m] [LawfulFunctor m]
+    (f : α → β) (x : AddWriterT Cost m α) :
+    (f <$> x).value = f <$> x.value := by
+  simp [value]
+
+@[simp] theorem cost_map [Functor m] [LawfulFunctor m]
+    (f : α → β) (x : AddWriterT Cost m α) :
+    (f <$> x).cost = x.cost := by
+  simp [cost]
+
+theorem value_bind [Monad m] [LawfulMonad m] [Add Cost]
+    (x : AddWriterT Cost m α) (f : α → AddWriterT Cost m β) :
+    (x >>= f).value = (do
+      let a ← x.run
+      (f a.ret).value) := by
+  simp [value, run_bind]
+
+theorem cost_bind [Monad m] [LawfulMonad m] [Add Cost]
+    (x : AddWriterT Cost m α) (f : α → AddWriterT Cost m β) :
+    (x >>= f).cost = (do
+      let a ← x.run
+      let b ← (f a.ret).run
+      pure (a.tell + b.tell)) := by
+  simp only [cost, run_bind, map_bind, map_pure]
+
+theorem run_injective {x y : AddWriterT Cost m α} (h : x.run = y.run) : x = y := h
+
+instance [Monad m] [LawfulMonad m] [AddMonoid Cost] : LawfulMonad (AddWriterT Cost m) :=
+  LawfulMonad.mk'
+    (id_map := fun x => run_injective (by simp))
+    (pure_bind := fun a f => run_injective (by simp))
+    (bind_assoc := fun x f g => run_injective (by simp [bind_assoc, add_assoc]))
+    (bind_pure_comp := fun f x => run_injective (by simp [add_zero]))
+
+end AddWriterT
+end Algolean

--- a/Algolean/FreeWP/WP.lean
+++ b/Algolean/FreeWP/WP.lean
@@ -131,17 +131,15 @@ def wpH (H : LHandler F ps) (x : FreeM F α) : PredTrans ps α :=
 
 theorem wpH_liftBind (H : LHandler F ps) {ι : Type u}
     (op : F ι) (k : ι → FreeM F α) :
-    wpH H ((lift op : FreeM F ι) >>= k) = H op >>= fun x => wpH H (k x) := by
-  change wpH H (liftBind op k) = _
-  rfl
+    wpH H ((lift op : FreeM F ι) >>= k) = H op >>= fun x => wpH H (k x) := rfl
 
 theorem wpH_lift (H : LHandler F ps) {ι : Type u} (op : F ι) :
     wpH H (lift op : FreeM F ι) = H op :=
   liftM_lift _ op
 
 @[simp] theorem wpH_bind (H : LHandler F ps) (x : FreeM F α) (f : α → FreeM F β) :
-    wpH H (x >>= f) = wpH H x >>= fun a => wpH H (f a) := by
-  simpa only [wpH, bind_eq_bind] using liftM_bind _ x f
+    wpH H (x >>= f) = wpH H x >>= fun a => wpH H (f a) :=
+  liftM_bind H x f
 
 /-- Adequacy theorem: WP via `FreeM` against an `ofInterp`-derived handler agrees with
 `Std.Do`'s WP of the `liftM` interpretation. Equivalently, two monad morphisms

--- a/Algolean/FreeWP/WP.lean
+++ b/Algolean/FreeWP/WP.lean
@@ -26,8 +26,16 @@ The WP's structural rules (`wpH_pure`, `wpH_bind`, …) are immediate from `lift
 morphism; the adequacy theorem `wpH_ofInterp_eq_wp_liftM` — that WP-via-handler agrees with
 `Std.Do`'s WP of the `liftM` interpretation — is the same statement of uniqueness.
 
+For pure specifications, an `OperationSpec F` assigns an arbitrary precondition and relational
+postcondition to every operation in `F`. Its `toHandler` method compiles these contracts into
+logical handlers. This is the free-monad construction from Maillard et al.,
+[*Dijkstra Monads for All*][Maillard2019]: because `FreeM F` imposes no equations on operation
+trees, the primitive contracts extend freely to a compositional weakest-precondition semantics.
+
 The design follows [Vistrup, Sammler, Jung. *Program Logics à la Carte.* POPL 2025], adapted
 from coinductive ITrees to inductive `FreeM` and from Iris to `Std.Do`.
+
+[Maillard2019]: https://arxiv.org/abs/1903.01237
 -/
 
 @[expose] public section
@@ -48,6 +56,42 @@ variable {F G : Type u → Type v} {ps : PostShape.{u}} {α β : Type u}
 `PredTrans ps`. -/
 abbrev LHandler (F : Type u → Type v) (ps : PostShape.{u}) : Type (max (u + 1) v) :=
   ∀ {ι : Type u}, F ι → PredTrans ps ι
+
+/-- A relational specification for every operation in an indexed signature `F`.
+
+An operation `op : F ι` packages its operation name and input and returns a value of type `ι`.
+`pre op` must hold before invoking it, while `post op out` characterizes the outputs that the
+operation is allowed to return. Because `FreeM F` is free of equations, these contracts may be
+chosen independently for each operation. -/
+structure OperationSpec (F : Type u → Type v) : Type (max (u + 1) v) where
+  /-- Preconditions for primitive operations. -/
+  pre {ι : Type u} (op : F ι) : Prop
+  /-- Relational postconditions for primitive operations and their outputs. -/
+  post {ι : Type u} (op : F ι) (out : ι) : Prop
+
+namespace OperationSpec
+
+/-- Compile relational operation contracts into a pure logical handler.
+
+For `op : F ι` and a continuation postcondition `Q`, the resulting weakest precondition is
+`S.pre op ∧ ∀ out, S.post op out → Q out`: the operation must be enabled, and every output
+permitted by its relational postcondition must make the continuation safe. -/
+def toHandler (S : OperationSpec F) : LHandler F .pure :=
+  fun op =>
+    { trans := fun Q =>
+        spred(⌜S.pre op ∧ ∀ out, S.post op out → (Q.1 out).down⌝)
+      conjunctiveRaw := by
+        intro Q₁ Q₂
+        aesop }
+
+@[simp]
+theorem apply_toHandler (S : OperationSpec F) {ι : Type u} (op : F ι)
+    (Q : PostCond ι .pure) :
+    (S.toHandler op).apply Q =
+      spred(⌜S.pre op ∧ ∀ out, S.post op out → (Q.1 out).down⌝) :=
+  rfl
+
+end OperationSpec
 
 namespace LHandler
 
@@ -124,6 +168,14 @@ instance instWPFreeM [HasHandler F ps] : WP (FreeM F) ps where
 instance instWPMonadFreeM [HasHandler F ps] : WPMonad (FreeM F) ps where
   wp_pure _ := rfl
   wp_bind x f := wpH_bind _ x f
+
+/-- The generic Hoare rule for a primitive `FreeM` operation. Its precondition is exactly the
+predicate transformer assigned by the selected logical handler. Its low `mvcgen` priority lets
+effect-specific rules expose more useful preconditions when available. -/
+@[spec low]
+theorem Spec.lift_FreeM [HasHandler F ps] (op : F α) {Q : PostCond α ps} :
+    Triple (lift op : FreeM F α) ((HasHandler.handler op).apply Q) Q :=
+  Triple.iff.mpr SPred.entails.rfl
 
 end FreeM
 

--- a/Algolean/ModelM.lean
+++ b/Algolean/ModelM.lean
@@ -206,6 +206,11 @@ theorem runM_value [Monad m] [LawfulMonad m] [AddMonoid Cost]
       (M.evalQuery q >>= fun a => (M.cost q + ·) <$> costM (f a) M) := by
   simp [costM, runM, ModelM.runQuery, AddWriterT.cost, AddWriterT.run_bind]
 
+@[simp] theorem costM_map [Monad m] [LawfulMonad m] [AddMonoid Cost]
+    (f : α → β) (P : Prog Q α) (M : ModelM Q m Cost) :
+    costM (f <$> P) M = costM P M := by
+  simp [costM]
+
 section OfModel
 
 variable {Q : Type u → Type u} {Cost : Type u}

--- a/Algolean/ModelM.lean
+++ b/Algolean/ModelM.lean
@@ -26,8 +26,11 @@ namespace Algolean.Algorithms
 
 open Cslib
 
+/-- A query model whose queries are evaluated in the monad `m`. -/
 structure ModelM (Q : Type u → Type v) (m : Type u → Type w) (Cost : Type u) where
+  /-- Evaluate a query in `m`. -/
   evalQuery : Q α → m α
+  /-- The cost assigned to a query. -/
   cost : Q α → Cost
 
 namespace ModelM
@@ -48,11 +51,6 @@ def runQuery [Functor m] (M : ModelM Q m Cost) (q : Q α) : AddWriterT Cost m α
     (M.runQuery q).cost = (fun _ => M.cost q) <$> M.evalQuery q := by
   simp [runQuery, AddWriterT.cost]
 
-/-- Construct a model from an evaluator and a cost function. -/
-def ofEvalCost (evalQuery : {α : Type u} → Q α → m α)
-    (cost : {α : Type u} → Q α → Cost) : ModelM Q m Cost :=
-  ⟨evalQuery, cost⟩
-
 /-- Regard a `Model` as a `ModelM` over `Id`. -/
 def ofModel (M : Algolean.Algorithms.Model Q Cost) : ModelM Q Id Cost where
   evalQuery q := M.evalQuery q
@@ -63,20 +61,6 @@ def ofModel (M : Algolean.Algorithms.Model Q Cost) : ModelM Q Id Cost where
 
 @[simp] theorem ofModel_cost (M : Algolean.Algorithms.Model Q Cost) (q : Q α) :
     (ofModel M).cost q = M.cost q := rfl
-
-/-- Change the semantic monad through a natural transformation. -/
-def mapK {n : Type u → Type y} (lift : {α : Type u} → m α → n α)
-    (M : ModelM Q m Cost) : ModelM Q n Cost where
-  evalQuery q := lift (M.evalQuery q)
-  cost q := M.cost q
-
-@[simp] theorem mapK_evalQuery {n : Type u → Type y}
-    (lift : {α : Type u} → m α → n α) (M : ModelM Q m Cost) (q : Q α) :
-    (M.mapK lift).evalQuery q = lift (M.evalQuery q) := rfl
-
-@[simp] theorem mapK_cost {n : Type u → Type y}
-    (lift : {α : Type u} → m α → n α) (M : ModelM Q m Cost) (q : Q α) :
-    (M.mapK lift).cost q = M.cost q := rfl
 
 /-- Sum two query languages interpreted in the same monad with the same cost type. -/
 def sum {Q₂ : Type u → Type x} (M₁ : ModelM Q m Cost) (M₂ : ModelM Q₂ m Cost) :
@@ -129,7 +113,7 @@ def costM [Monad m] [AddZero Cost]
 
 @[simp] theorem evalM_liftBind [Monad m]
     (q : Q α) (f : α → Prog Q β) (M : ModelM Q m Cost) :
-    evalM (FreeM.liftBind q f) M = (M.evalQuery q >>= fun a => evalM (f a) M) := rfl
+    evalM (FreeM.lift q >>= f) M = (M.evalQuery q >>= fun a => evalM (f a) M) := rfl
 
 @[simp] theorem evalM_lift [Monad m] [LawfulMonad m]
     (q : Q α) (M : ModelM Q m Cost) :
@@ -152,7 +136,7 @@ def costM [Monad m] [AddZero Cost]
 
 @[simp] theorem runM_liftBind [Monad m] [AddZero Cost]
     (q : Q α) (f : α → Prog Q β) (M : ModelM Q m Cost) :
-    runM (FreeM.liftBind q f) M = (M.runQuery q >>= fun a => runM (f a) M) := rfl
+    runM (FreeM.lift q >>= f) M = (M.runQuery q >>= fun a => runM (f a) M) := rfl
 
 @[simp] theorem runM_lift [Monad m] [LawfulMonad m] [AddMonoid Cost]
     (q : Q α) (M : ModelM Q m Cost) :
@@ -170,13 +154,14 @@ def costM [Monad m] [AddZero Cost]
   simp [runM]
 
 /-- Forgetting the cost component of the joint semantics recovers `evalM`. -/
-theorem runM_value [Monad m] [LawfulMonad m] [AddMonoid Cost]
+@[simp] theorem runM_value [Monad m] [LawfulMonad m] [AddZero Cost]
     (P : Prog Q α) (M : ModelM Q m Cost) :
     (P.runM M).value = P.evalM M := by
   induction P with
   | pure a => simp
   | liftBind q f ih =>
-      simp only [runM_liftBind, evalM_liftBind, AddWriterT.value_bind,
+      simp only [runM, evalM] at ih
+      simp only [runM, evalM, FreeM.liftM, AddWriterT.value_bind,
         ModelM.runQuery, AddWriterT.run_mk, ih, bind_map_left]
 
 @[simp] theorem costM_pure [Monad m] [LawfulMonad m] [AddZero Cost]
@@ -184,9 +169,9 @@ theorem runM_value [Monad m] [LawfulMonad m] [AddMonoid Cost]
     costM (pure a : Prog Q α) M = pure 0 := by
   simp [costM]
 
-@[simp] theorem costM_liftBind [Monad m] [LawfulMonad m] [AddMonoid Cost]
+@[simp] theorem costM_liftBind [Monad m] [LawfulMonad m] [AddZero Cost]
     (q : Q α) (f : α → Prog Q β) (M : ModelM Q m Cost) :
-    costM (FreeM.liftBind q f) M =
+    costM (FreeM.lift q >>= f) M =
       (M.evalQuery q >>= fun a => (M.cost q + ·) <$> costM (f a) M) := by
   simp [costM, runM, ModelM.runQuery, AddWriterT.cost, AddWriterT.run_bind]
 
@@ -197,31 +182,23 @@ theorem runM_value [Monad m] [LawfulMonad m] [AddMonoid Cost]
 
 section OfModel
 
-variable {Q : Type u → Type u} {Cost : Type u}
-
 /-- Evaluating with `ofModel M` is the same as evaluating with `M`. -/
-theorem evalM_ofModel (P : Prog Q α) (M : Algolean.Algorithms.Model Q Cost) :
-    Id.run (P.evalM (ModelM.ofModel M)) = P.eval M := by
-  induction P with
-  | pure a => rfl
-  | liftBind q f ih => exact ih (M.evalQuery q)
+@[simp] theorem evalM_ofModel (P : Prog Q α) (M : Algolean.Algorithms.Model Q Cost) :
+    Id.run (P.evalM (ModelM.ofModel M)) = P.eval M := rfl
 
 /-- The cost of a query followed by a program under `ofModel`. -/
-@[simp] theorem costM_ofModel_liftBind [AddMonoid Cost]
+@[simp] theorem costM_ofModel_liftBind [AddZero Cost]
     (q : Q α) (f : α → Prog Q β) (M : Algolean.Algorithms.Model Q Cost) :
-    Id.run (Prog.costM (FreeM.liftBind q f) (ModelM.ofModel M)) =
-      M.cost q + Id.run ((f (M.evalQuery q)).costM (ModelM.ofModel M)) := by
-  rw [costM_liftBind]
-  rfl
+    Id.run (Prog.costM (FreeM.lift q >>= f) (ModelM.ofModel M)) =
+      M.cost q + Id.run ((f (M.evalQuery q)).costM (ModelM.ofModel M)) := rfl
 
 /-- Computing cost with `ofModel M` gives `Prog.time M`. -/
-theorem costM_ofModel [AddMonoid Cost]
+@[simp] theorem costM_ofModel [AddZero Cost]
     (P : Prog Q α) (M : Algolean.Algorithms.Model Q Cost) :
     Id.run (P.costM (ModelM.ofModel M)) = P.time M := by
   induction P with
-  | pure a => simp
-  | liftBind q f ih =>
-      rw [costM_ofModel_liftBind, Prog.time_liftBind, ih]
+  | pure a => rfl
+  | liftBind q f ih => exact congrArg (M.cost q + ·) (ih (M.evalQuery q))
 
 end OfModel
 
@@ -229,42 +206,29 @@ section Reduction
 
 variable {Q₁ Q₂ : Type u → Type u}
 
-
-/-- Reducing a program does not change its evaluation if the reduction preserves each query. -/
+/-- A query reduction preserving each query also preserves program evaluation. -/
 theorem reduceProg_evalM [Monad m] [LawfulMonad m]
     (P : Prog Q₁ α) (red : Reduction Q₁ Q₂)
-    (M₁ : ModelM Q₁ m Cost) (M₂ : ModelM Q₂ m Cost)
+    (M₁ : ModelM Q₁ m Cost₁) (M₂ : ModelM Q₂ m Cost₂)
     (hCorrect : ∀ {ι} (q : Q₁ ι), (red.reduce q).evalM M₂ = M₁.evalQuery q) :
-    (P.reduceProg red).evalM M₂ = P.evalM M₁ := by
-  induction P with
-  | pure a => rfl
-  | liftBind q f ih =>
-      simp only [Prog.reduceProg, evalM, FreeM.liftBind_eq, FreeM.bind_eq_bind,
-        FreeM.liftM_bind, FreeM.liftM_lift]
-      have hq : FreeM.liftM M₂.evalQuery (red.reduce q) = M₁.evalQuery q := by
-        apply hCorrect
-      rw [hq]
-      apply congrArg (fun k : _ → m α => M₁.evalQuery q >>= k)
-      funext a
-      apply ih
+    (P.reduceProg red).evalM M₂ = P.evalM M₁ :=
+  reduceProg_liftM P red M₁.evalQuery M₂.evalQuery hCorrect
 
 /-- A query reduction preserving `runM` also preserves `runM` for every program. -/
 theorem reduceProg_runM [Monad m] [LawfulMonad m] [AddMonoid Cost]
     (P : Prog Q₁ α) (red : Reduction Q₁ Q₂)
     (M₁ : ModelM Q₁ m Cost) (M₂ : ModelM Q₂ m Cost)
     (hCorrect : ∀ {ι} (q : Q₁ ι), (red.reduce q).runM M₂ = M₁.runQuery q) :
-    (P.reduceProg red).runM M₂ = P.runM M₁ := by
-  induction P with
-  | pure a => rfl
-  | liftBind q f ih =>
-      simp only [Prog.reduceProg, runM, FreeM.liftBind_eq, FreeM.bind_eq_bind,
-        FreeM.liftM_bind, FreeM.liftM_lift]
-      have hq : FreeM.liftM M₂.runQuery (red.reduce q) = M₁.runQuery q := by
-        apply hCorrect
-      rw [hq]
-      apply congrArg (fun k : _ → AddWriterT Cost m α => M₁.runQuery q >>= k)
-      funext a
-      apply ih
+    (P.reduceProg red).runM M₂ = P.runM M₁ :=
+  reduceProg_liftM P red M₁.runQuery M₂.runQuery hCorrect
+
+/-- A query reduction preserving `runM` also preserves accumulated program costs. -/
+theorem reduceProg_costM [Monad m] [LawfulMonad m] [AddMonoid Cost]
+    (P : Prog Q₁ α) (red : Reduction Q₁ Q₂)
+    (M₁ : ModelM Q₁ m Cost) (M₂ : ModelM Q₂ m Cost)
+    (hCorrect : ∀ {ι} (q : Q₁ ι), (red.reduce q).runM M₂ = M₁.runQuery q) :
+    (P.reduceProg red).costM M₂ = P.costM M₁ :=
+  congrArg AddWriterT.cost (reduceProg_runM P red M₁ M₂ hCorrect)
 
 end Reduction
 
@@ -282,6 +246,11 @@ namespace ModelM
 def handler [WP m ps] (M : ModelM Q m Cost) : LHandler Q ps :=
   LHandler.ofInterp (m := m) (fun _ q => M.evalQuery q)
 
+@[simp] theorem handler_sum [WP m ps] {Q₂ : Type u → Type x}
+    (M₁ : ModelM Q m Cost) (M₂ : ModelM Q₂ m Cost) (q : Q α ⊕ Q₂ α) :
+    (M₁.sum M₂).handler q = LHandler.sum M₁.handler M₂.handler q := by
+  cases q <;> rfl
+
 /-- Use `M.handler` as the logical handler for `Prog Q`. -/
 @[reducible] def hasHandler [WP m ps] (M : ModelM Q m Cost) : HasHandler Q ps where
   handler := M.handler
@@ -289,19 +258,10 @@ def handler [WP m ps] (M : ModelM Q m Cost) : LHandler Q ps :=
 /-- The weakest precondition given by `M.handler` agrees with that of `Prog.evalM M`. -/
 theorem wp_eq_wp_evalM [Monad m] [WPMonad m ps]
     (M : ModelM Q m Cost) (P : Prog Q α) :
-    wpH M.handler P = wp (P.evalM M) := by
-  unfold ModelM.handler Prog.evalM
-  exact wpH_ofInterp_eq_wp_liftM (m := m) (fun _ q => M.evalQuery q) P
+    wpH M.handler P = wp (P.evalM M) :=
+  wpH_ofInterp_eq_wp_liftM (m := m) (fun _ q => M.evalQuery q) P
 
 end ModelM
-
-/-- The weakest-precondition rule for a query under the selected logical handler. -/
-@[spec]
-theorem Spec.queryM [HasHandler Q ps] (q : Q α) {Q' : PostCond α ps} :
-    Triple (FreeM.lift q : Prog Q α) ((HasHandler.handler q).apply Q') Q' := by
-  apply Triple.of_entails_wp
-  rw [show wp (FreeM.lift q : Prog Q α) =
-    wpH HasHandler.handler (FreeM.lift q) from rfl, wpH_lift]
 
 /-- The `ModelM` query rule stated directly through the semantic monad's weakest precondition. -/
 theorem ModelM.query_spec [Monad m] [WPMonad m ps]
@@ -309,7 +269,7 @@ theorem ModelM.query_spec [Monad m] [WPMonad m ps]
     let _ : HasHandler Q ps := M.hasHandler
     Triple (FreeM.lift q : Prog Q α) (wp⟦M.evalQuery q⟧ Q') Q' := by
   letI := M.hasHandler
-  exact Spec.queryM q
+  exact Cslib.FreeM.Spec.lift_FreeM q
 
 end WeakestPrecondition
 

--- a/Algolean/ModelM.lean
+++ b/Algolean/ModelM.lean
@@ -1,0 +1,284 @@
+/-
+Copyright (c) 2026 Tanner Duve. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tanner Duve
+-/
+
+module
+
+public import Algolean.AddWriter.Transformer
+public import Algolean.QueryModel
+
+/-!
+# Monadic query models
+
+`ModelM` is a parallel, effectful counterpart to `Model`. It leaves the existing deterministic API
+unchanged and interprets the same `Prog Q α` syntax in an arbitrary monad `m`.
+
+Evaluation and per-query cost remain separate. `Prog.runM` combines them with `AddWriterT`, so
+effect-dependent control flow produces branch-correlated results and total costs.
+-/
+
+@[expose] public section
+
+namespace Algolean.Algorithms
+
+open Cslib
+
+structure ModelM (Q : Type u → Type v) (m : Type u → Type w) (Cost : Type u) where
+  evalQuery : Q α → m α
+  cost : Q α → Cost
+
+namespace ModelM
+
+variable {Q : Type u → Type v} {m : Type u → Type w} {Cost : Type u}
+
+/-- Interpret one query jointly, pairing every semantic branch with the query's fixed cost. -/
+def runQuery [Functor m] (M : ModelM Q m Cost) (q : Q α) : AddWriterT Cost m α :=
+  AddWriterT.mk ((fun result => ⟨result, M.cost q⟩) <$> M.evalQuery q)
+
+@[simp] theorem runQuery_value [Functor m] [LawfulFunctor m]
+    (M : ModelM Q m Cost) (q : Q α) :
+    (M.runQuery q).value = M.evalQuery q := by
+  simp [runQuery, AddWriterT.value]
+
+@[simp] theorem runQuery_cost [Functor m] [LawfulFunctor m]
+    (M : ModelM Q m Cost) (q : Q α) :
+    (M.runQuery q).cost = (fun _ => M.cost q) <$> M.evalQuery q := by
+  simp [runQuery, AddWriterT.cost]
+
+/-- Construct an effectful model from its separate evaluator and cost functions. -/
+def ofEvalCost (evalQuery : {α : Type u} → Q α → m α)
+    (cost : {α : Type u} → Q α → Cost) : ModelM Q m Cost :=
+  ⟨evalQuery, cost⟩
+
+/-- Lift an existing deterministic model into `Id` without changing its semantics. -/
+def ofModel (M : Algolean.Algorithms.Model Q Cost) : ModelM Q Id Cost where
+  evalQuery q := M.evalQuery q
+  cost q := M.cost q
+
+@[simp] theorem ofModel_evalQuery (M : Algolean.Algorithms.Model Q Cost) (q : Q α) :
+    (ofModel M).evalQuery q = M.evalQuery q := rfl
+
+@[simp] theorem ofModel_cost (M : Algolean.Algorithms.Model Q Cost) (q : Q α) :
+    (ofModel M).cost q = M.cost q := rfl
+
+/-- Change the semantic monad through a polymorphic natural transformation. -/
+def mapK {n : Type u → Type y} (lift : {α : Type u} → m α → n α)
+    (M : ModelM Q m Cost) : ModelM Q n Cost where
+  evalQuery q := lift (M.evalQuery q)
+  cost q := M.cost q
+
+@[simp] theorem mapK_evalQuery {n : Type u → Type y}
+    (lift : {α : Type u} → m α → n α) (M : ModelM Q m Cost) (q : Q α) :
+    (M.mapK lift).evalQuery q = lift (M.evalQuery q) := rfl
+
+@[simp] theorem mapK_cost {n : Type u → Type y}
+    (lift : {α : Type u} → m α → n α) (M : ModelM Q m Cost) (q : Q α) :
+    (M.mapK lift).cost q = M.cost q := rfl
+
+/-- Sum two query languages interpreted in the same monad with the same cost type. -/
+def sum {Q₂ : Type u → Type x} (M₁ : ModelM Q m Cost) (M₂ : ModelM Q₂ m Cost) :
+    ModelM (fun α => Sum (Q α) (Q₂ α)) m Cost where
+  evalQuery
+    | .inl q => M₁.evalQuery q
+    | .inr q => M₂.evalQuery q
+  cost
+    | .inl q => M₁.cost q
+    | .inr q => M₂.cost q
+
+@[simp] theorem sum_evalQuery_inl {Q₂ : Type u → Type x}
+    (M₁ : ModelM Q m Cost) (M₂ : ModelM Q₂ m Cost) (q : Q α) :
+    (M₁.sum M₂).evalQuery (.inl q) = M₁.evalQuery q := rfl
+
+@[simp] theorem sum_evalQuery_inr {Q₂ : Type u → Type x}
+    (M₁ : ModelM Q m Cost) (M₂ : ModelM Q₂ m Cost) (q : Q₂ α) :
+    (M₁.sum M₂).evalQuery (.inr q) = M₂.evalQuery q := rfl
+
+@[simp] theorem sum_cost_inl {Q₂ : Type u → Type x}
+    (M₁ : ModelM Q m Cost) (M₂ : ModelM Q₂ m Cost) (q : Q α) :
+    (M₁.sum M₂).cost (.inl q) = M₁.cost q := rfl
+
+@[simp] theorem sum_cost_inr {Q₂ : Type u → Type x}
+    (M₁ : ModelM Q m Cost) (M₂ : ModelM Q₂ m Cost) (q : Q₂ α) :
+    (M₁.sum M₂).cost (.inr q) = M₂.cost q := rfl
+
+/-- Sum models with distinct cost types, recording their costs in separate product components. -/
+def compose {Q₂ : Type u → Type x} {Cost₂ : Type u} [Zero Cost] [Zero Cost₂]
+    (M₁ : ModelM Q m Cost) (M₂ : ModelM Q₂ m Cost₂) :
+    ModelM (fun α => Sum (Q α) (Q₂ α)) m (Cost × Cost₂) where
+  evalQuery
+    | .inl q => M₁.evalQuery q
+    | .inr q => M₂.evalQuery q
+  cost
+    | .inl q => (M₁.cost q, 0)
+    | .inr q => (0, M₂.cost q)
+
+@[simp] theorem compose_evalQuery_inl {Q₂ : Type u → Type x} {Cost₂ : Type u}
+    [Zero Cost] [Zero Cost₂] (M₁ : ModelM Q m Cost) (M₂ : ModelM Q₂ m Cost₂) (q : Q α) :
+    (M₁.compose M₂).evalQuery (.inl q) = M₁.evalQuery q := rfl
+
+@[simp] theorem compose_evalQuery_inr {Q₂ : Type u → Type x} {Cost₂ : Type u}
+    [Zero Cost] [Zero Cost₂] (M₁ : ModelM Q m Cost) (M₂ : ModelM Q₂ m Cost₂) (q : Q₂ α) :
+    (M₁.compose M₂).evalQuery (.inr q) = M₂.evalQuery q := rfl
+
+@[simp] theorem compose_cost_inl {Q₂ : Type u → Type x} {Cost₂ : Type u}
+    [Zero Cost] [Zero Cost₂] (M₁ : ModelM Q m Cost) (M₂ : ModelM Q₂ m Cost₂) (q : Q α) :
+    (M₁.compose M₂).cost (.inl q) = (M₁.cost q, 0) := rfl
+
+@[simp] theorem compose_cost_inr {Q₂ : Type u → Type x} {Cost₂ : Type u}
+    [Zero Cost] [Zero Cost₂] (M₁ : ModelM Q m Cost) (M₂ : ModelM Q₂ m Cost₂) (q : Q₂ α) :
+    (M₁.compose M₂).cost (.inr q) = (0, M₂.cost q) := rfl
+
+end ModelM
+
+namespace Prog
+
+variable {Q : Type u → Type v} {m : Type u → Type w} {Cost : Type u}
+
+/-- Evaluate a query program in the semantic monad of `M`. -/
+def evalM [Monad m] (P : Prog Q α) (M : ModelM Q m Cost) : m α :=
+  P.liftM M.evalQuery
+
+/-- Evaluate a program while accumulating branch-correlated query costs. -/
+def runM [Monad m] [AddZero Cost]
+    (P : Prog Q α) (M : ModelM Q m Cost) : AddWriterT Cost m α :=
+  P.liftM M.runQuery
+
+/-- The effectful total-cost marginal of `runM`. -/
+def costM [Monad m] [AddZero Cost]
+    (P : Prog Q α) (M : ModelM Q m Cost) : m Cost :=
+  (P.runM M).cost
+
+@[simp] theorem evalM_pure [Monad m] (a : α) (M : ModelM Q m Cost) :
+    evalM (pure a : Prog Q α) M = pure a := rfl
+
+@[simp] theorem evalM_liftBind [Monad m]
+    (q : Q α) (f : α → Prog Q β) (M : ModelM Q m Cost) :
+    evalM (FreeM.liftBind q f) M = (M.evalQuery q >>= fun a => evalM (f a) M) := rfl
+
+@[simp] theorem evalM_lift [Monad m] [LawfulMonad m]
+    (q : Q α) (M : ModelM Q m Cost) :
+    evalM (FreeM.lift q) M = M.evalQuery q := by
+  simp [evalM]
+
+@[simp] theorem evalM_bind [Monad m] [LawfulMonad m]
+    (P : Prog Q α) (f : α → Prog Q β) (M : ModelM Q m Cost) :
+    evalM (P >>= f) M = (evalM P M >>= fun a => evalM (f a) M) := by
+  simp [evalM]
+
+@[simp] theorem evalM_map [Monad m] [LawfulMonad m]
+    (f : α → β) (P : Prog Q α) (M : ModelM Q m Cost) :
+    evalM (f <$> P) M = f <$> evalM P M := by
+  simp [evalM]
+
+@[simp] theorem runM_pure [Monad m] [AddZero Cost]
+    (a : α) (M : ModelM Q m Cost) :
+    runM (pure a : Prog Q α) M = pure a := rfl
+
+@[simp] theorem runM_liftBind [Monad m] [AddZero Cost]
+    (q : Q α) (f : α → Prog Q β) (M : ModelM Q m Cost) :
+    runM (FreeM.liftBind q f) M = (M.runQuery q >>= fun a => runM (f a) M) := rfl
+
+@[simp] theorem runM_lift [Monad m] [LawfulMonad m] [AddMonoid Cost]
+    (q : Q α) (M : ModelM Q m Cost) :
+    runM (FreeM.lift q) M = M.runQuery q := by
+  simp [runM]
+
+@[simp] theorem runM_bind [Monad m] [LawfulMonad m] [AddMonoid Cost]
+    (P : Prog Q α) (f : α → Prog Q β) (M : ModelM Q m Cost) :
+    runM (P >>= f) M = (runM P M >>= fun a => runM (f a) M) := by
+  simp [runM]
+
+@[simp] theorem runM_map [Monad m] [LawfulMonad m] [AddMonoid Cost]
+    (f : α → β) (P : Prog Q α) (M : ModelM Q m Cost) :
+    runM (f <$> P) M = f <$> runM P M := by
+  simp [runM]
+
+/-- Forgetting the cost component of the joint semantics recovers `evalM`. -/
+theorem runM_value [Monad m] [LawfulMonad m] [AddMonoid Cost]
+    (P : Prog Q α) (M : ModelM Q m Cost) :
+    (P.runM M).value = P.evalM M := by
+  induction P with
+  | pure a => simp
+  | liftBind q f ih =>
+      simp only [runM_liftBind, evalM_liftBind, AddWriterT.value_bind,
+        ModelM.runQuery, AddWriterT.run_mk]
+      simp [ih]
+
+@[simp] theorem costM_pure [Monad m] [LawfulMonad m] [AddZero Cost]
+    (a : α) (M : ModelM Q m Cost) :
+    costM (pure a : Prog Q α) M = pure 0 := by
+  simp [costM]
+
+section DeterministicBridge
+
+variable {Q : Type u → Type u} {Cost : Type u}
+
+/-- `evalM` under a lifted deterministic model agrees with the existing evaluator. -/
+theorem evalM_ofModel (P : Prog Q α) (M : Algolean.Algorithms.Model Q Cost) :
+    Id.run (P.evalM (ModelM.ofModel M)) = P.eval M := by
+  induction P with
+  | pure a => rfl
+  | liftBind q f ih => exact ih (M.evalQuery q)
+
+/-- `costM` under a lifted deterministic model agrees with existing `Prog.time`. -/
+theorem costM_ofModel [AddMonoid Cost]
+    (P : Prog Q α) (M : Algolean.Algorithms.Model Q Cost) :
+    Id.run (P.costM (ModelM.ofModel M)) = P.time M := by
+  induction P with
+  | pure a => simp [costM, runM, Prog.time]
+  | liftBind q f ih =>
+      change M.cost q + Id.run ((runM (f (M.evalQuery q)) (ModelM.ofModel M)).cost) =
+        M.cost q + Prog.time (f (M.evalQuery q)) M
+      simpa [costM] using
+        congrArg (fun c => M.cost q + c) (ih (M.evalQuery q))
+
+end DeterministicBridge
+
+section Reduction
+
+variable {Q₁ Q₂ : Type u → Type u}
+
+/-- A syntax-level reduction preserves effectful evaluation when it implements every source query
+in the target model. The existing `Reduction` structure is sufficient; only its correctness
+criterion changes for effectful models. -/
+theorem reduceProg_evalM [Monad m] [LawfulMonad m]
+    (P : Prog Q₁ α) (red : Reduction Q₁ Q₂)
+    (M₁ : ModelM Q₁ m Cost) (M₂ : ModelM Q₂ m Cost)
+    (hCorrect : ∀ {ι} (q : Q₁ ι), (red.reduce q).evalM M₂ = M₁.evalQuery q) :
+    (P.reduceProg red).evalM M₂ = P.evalM M₁ := by
+  induction P with
+  | pure a => rfl
+  | liftBind q f ih =>
+      simp only [Prog.reduceProg, evalM, FreeM.liftBind_eq, FreeM.bind_eq_bind,
+        FreeM.liftM_bind, FreeM.liftM_lift]
+      have hq : FreeM.liftM M₂.evalQuery (red.reduce q) = M₁.evalQuery q := by
+        simpa only [evalM] using hCorrect q
+      rw [hq]
+      apply congrArg (fun k : _ → m α => M₁.evalQuery q >>= k)
+      funext a
+      simpa only [evalM, Prog.reduceProg] using ih a
+
+/-- The stronger joint criterion preserves results and branch-correlated accumulated costs. -/
+theorem reduceProg_runM [Monad m] [LawfulMonad m] [AddMonoid Cost]
+    (P : Prog Q₁ α) (red : Reduction Q₁ Q₂)
+    (M₁ : ModelM Q₁ m Cost) (M₂ : ModelM Q₂ m Cost)
+    (hCorrect : ∀ {ι} (q : Q₁ ι), (red.reduce q).runM M₂ = M₁.runQuery q) :
+    (P.reduceProg red).runM M₂ = P.runM M₁ := by
+  induction P with
+  | pure a => rfl
+  | liftBind q f ih =>
+      simp only [Prog.reduceProg, runM, FreeM.liftBind_eq, FreeM.bind_eq_bind,
+        FreeM.liftM_bind, FreeM.liftM_lift]
+      have hq : FreeM.liftM M₂.runQuery (red.reduce q) = M₁.runQuery q := by
+        simpa only [runM] using hCorrect q
+      rw [hq]
+      apply congrArg (fun k : _ → AddWriterT Cost m α => M₁.runQuery q >>= k)
+      funext a
+      simpa only [runM, Prog.reduceProg] using ih a
+
+end Reduction
+
+end Prog
+end Algolean.Algorithms

--- a/Algolean/ModelM.lean
+++ b/Algolean/ModelM.lean
@@ -12,19 +12,12 @@ public import Algolean.QueryModel
 /-!
 # Monadic query models
 
-`ModelM` is a parallel, effectful counterpart to `Model`. It leaves the existing deterministic API
-unchanged and interprets the same `Prog Q α` syntax in an arbitrary monad `m`.
+`ModelM` generalizes `Model` by allowing queries to be evaluated in any monad `m`.
+`Prog.evalM` evaluates a program, `Prog.runM` records its result and accumulated query cost, and
+`Prog.costM` returns the accumulated cost.
 
-`Prog.evalM` is the primary semantics. Evaluation and per-query cost remain separate in `ModelM`.
-`Prog.runM` records enough operational information to derive the runtime views used for randomized
-algorithms: expected runtime, worst-case runtime over random choices, high-probability runtime, and
-expected runtime conditioned on success. The joint result-cost value is supporting data rather than
-itself a complexity measure; conditioning on success is the reason the correlation must be retained.
-
-Value-correctness reasoning is independent of cost. A model whose semantic monad has a
-`Std.Do.WPMonad` supplies the same `mvcgen` infrastructure as the existing pure `Model` API through
-`ModelM.handler` and `ModelM.hasHandler`. Quantitative PMF reasoning remains a separate future
-layer.
+For a monad with a `Std.Do.WPMonad` instance, `ModelM.handler` and `ModelM.hasHandler` provide
+weakest-precondition semantics for `mvcgen`.
 -/
 
 @[expose] public section
@@ -41,7 +34,7 @@ namespace ModelM
 
 variable {Q : Type u → Type v} {m : Type u → Type w} {Cost : Type u}
 
-/-- Interpret one query jointly, pairing every semantic branch with the query's fixed cost. -/
+/-- Evaluate one query and record its cost. -/
 def runQuery [Functor m] (M : ModelM Q m Cost) (q : Q α) : AddWriterT Cost m α :=
   AddWriterT.mk ((fun result => ⟨result, M.cost q⟩) <$> M.evalQuery q)
 
@@ -55,12 +48,12 @@ def runQuery [Functor m] (M : ModelM Q m Cost) (q : Q α) : AddWriterT Cost m α
     (M.runQuery q).cost = (fun _ => M.cost q) <$> M.evalQuery q := by
   simp [runQuery, AddWriterT.cost]
 
-/-- Construct an effectful model from its separate evaluator and cost functions. -/
+/-- Construct a model from an evaluator and a cost function. -/
 def ofEvalCost (evalQuery : {α : Type u} → Q α → m α)
     (cost : {α : Type u} → Q α → Cost) : ModelM Q m Cost :=
   ⟨evalQuery, cost⟩
 
-/-- Lift an existing deterministic model into `Id` without changing its semantics. -/
+/-- Regard a `Model` as a `ModelM` over `Id`. -/
 def ofModel (M : Algolean.Algorithms.Model Q Cost) : ModelM Q Id Cost where
   evalQuery q := M.evalQuery q
   cost q := M.cost q
@@ -71,7 +64,7 @@ def ofModel (M : Algolean.Algorithms.Model Q Cost) : ModelM Q Id Cost where
 @[simp] theorem ofModel_cost (M : Algolean.Algorithms.Model Q Cost) (q : Q α) :
     (ofModel M).cost q = M.cost q := rfl
 
-/-- Change the semantic monad through a polymorphic natural transformation. -/
+/-- Change the semantic monad through a natural transformation. -/
 def mapK {n : Type u → Type y} (lift : {α : Type u} → m α → n α)
     (M : ModelM Q m Cost) : ModelM Q n Cost where
   evalQuery q := lift (M.evalQuery q)
@@ -121,21 +114,12 @@ variable {Q : Type u → Type v} {m : Type u → Type w} {Cost : Type u}
 def evalM [Monad m] (P : Prog Q α) (M : ModelM Q m Cost) : m α :=
   P.liftM M.evalQuery
 
-/-- Record results and accumulated costs in the same semantic branch.
-
-This is foundational data for runtime analyses, not a chosen notion of randomized complexity.
-Keeping the correlation is necessary for analyses such as expected runtime conditioned on success.
--/
+/-- Evaluate a query program while recording the accumulated query cost with each result. -/
 def runM [Monad m] [AddZero Cost]
     (P : Prog Q α) (M : ModelM Q m Cost) : AddWriterT Cost m α :=
   P.liftM M.runQuery
 
-/-- The total-runtime marginal of `runM`.
-
-For probabilistic semantics this is the runtime distribution used to derive expected, worst-case,
-and high-probability bounds. Analyses conditioned on the returned result must use `runM` so that
-the result-cost correlation is not discarded.
--/
+/-- The accumulated query cost of each execution of a program. -/
 def costM [Monad m] [AddZero Cost]
     (P : Prog Q α) (M : ModelM Q m Cost) : m Cost :=
   (P.runM M).cost
@@ -215,14 +199,14 @@ section OfModel
 
 variable {Q : Type u → Type u} {Cost : Type u}
 
-/-- `evalM` under `ofModel` agrees with the existing evaluator. -/
+/-- Evaluating with `ofModel M` is the same as evaluating with `M`. -/
 theorem evalM_ofModel (P : Prog Q α) (M : Algolean.Algorithms.Model Q Cost) :
     Id.run (P.evalM (ModelM.ofModel M)) = P.eval M := by
   induction P with
   | pure a => rfl
   | liftBind q f ih => exact ih (M.evalQuery q)
 
-/-- Under `ofModel`, one query contributes its cost and continues with its evaluated result. -/
+/-- The cost of a query followed by a program under `ofModel`. -/
 @[simp] theorem costM_ofModel_liftBind [AddMonoid Cost]
     (q : Q α) (f : α → Prog Q β) (M : Algolean.Algorithms.Model Q Cost) :
     Id.run (Prog.costM (FreeM.liftBind q f) (ModelM.ofModel M)) =
@@ -230,7 +214,7 @@ theorem evalM_ofModel (P : Prog Q α) (M : Algolean.Algorithms.Model Q Cost) :
   rw [costM_liftBind]
   rfl
 
-/-- `costM` under `ofModel` agrees with existing `Prog.time`. -/
+/-- Computing cost with `ofModel M` gives `Prog.time M`. -/
 theorem costM_ofModel [AddMonoid Cost]
     (P : Prog Q α) (M : Algolean.Algorithms.Model Q Cost) :
     Id.run (P.costM (ModelM.ofModel M)) = P.time M := by
@@ -246,9 +230,7 @@ section Reduction
 variable {Q₁ Q₂ : Type u → Type u}
 
 
-/-- A reduction preserves effectful evaluation when it implements every source query
-in the target model. The existing `Reduction` structure is sufficient; only its correctness
-criterion changes for effectful models. -/
+/-- Reducing a program does not change its evaluation if the reduction preserves each query. -/
 theorem reduceProg_evalM [Monad m] [LawfulMonad m]
     (P : Prog Q₁ α) (red : Reduction Q₁ Q₂)
     (M₁ : ModelM Q₁ m Cost) (M₂ : ModelM Q₂ m Cost)
@@ -266,7 +248,7 @@ theorem reduceProg_evalM [Monad m] [LawfulMonad m]
       funext a
       apply ih
 
-/-- The stronger joint criterion preserves results and branch-correlated accumulated costs. -/
+/-- A query reduction preserving `runM` also preserves `runM` for every program. -/
 theorem reduceProg_runM [Monad m] [LawfulMonad m] [AddMonoid Cost]
     (P : Prog Q₁ α) (red : Reduction Q₁ Q₂)
     (M₁ : ModelM Q₁ m Cost) (M₂ : ModelM Q₂ m Cost)
@@ -296,24 +278,15 @@ variable {ps : PostShape.{u}}
 
 namespace ModelM
 
-/-- The logical handler induced by the effectful evaluation semantics of `M`.
-
-The cost field is intentionally absent: ordinary Hoare triples specify value correctness under
-`evalM`. Cost-aware and quantitative probabilistic logics are separate analyses.
--/
+/-- The logical handler induced by `M.evalQuery`. -/
 def handler [WP m ps] (M : ModelM Q m Cost) : LHandler Q ps :=
   LHandler.ofInterp (m := m) (fun _ q => M.evalQuery q)
 
-/-- Select `M` as the logical interpretation of `Prog Q` in a local or scoped context.
-
-This is a value rather than a global instance because the same query syntax may have both a pure
-`Model` and one or more effectful `ModelM` interpretations.
--/
+/-- Use `M.handler` as the logical handler for `Prog Q`. -/
 @[reducible] def hasHandler [WP m ps] (M : ModelM Q m Cost) : HasHandler Q ps where
   handler := M.handler
 
-/-- Weakest-precondition reasoning through `M.handler` agrees with executing the program using
-`Prog.evalM M` whenever the semantic monad has a lawful weakest-precondition interpretation. -/
+/-- The weakest precondition given by `M.handler` agrees with that of `Prog.evalM M`. -/
 theorem wp_eq_wp_evalM [Monad m] [WPMonad m ps]
     (M : ModelM Q m Cost) (P : Prog Q α) :
     wpH M.handler P = wp (P.evalM M) := by
@@ -322,12 +295,7 @@ theorem wp_eq_wp_evalM [Monad m] [WPMonad m ps]
 
 end ModelM
 
-/-- Generic single-query rule for the currently selected logical handler.
-
-When the selected handler is `M.hasHandler`, this precondition reduces to
-`wp⟦M.evalQuery q⟧ Q'`. The rule lets `mvcgen` decompose effectful query programs without choosing a
-global `ModelM` for the query language.
--/
+/-- The weakest-precondition rule for a query under the selected logical handler. -/
 @[spec]
 theorem Spec.queryM [HasHandler Q ps] (q : Q α) {Q' : PostCond α ps} :
     Triple (FreeM.lift q : Prog Q α) ((HasHandler.handler q).apply Q') Q' := by

--- a/Algolean/ModelM.lean
+++ b/Algolean/ModelM.lean
@@ -15,8 +15,16 @@ public import Algolean.QueryModel
 `ModelM` is a parallel, effectful counterpart to `Model`. It leaves the existing deterministic API
 unchanged and interprets the same `Prog Q α` syntax in an arbitrary monad `m`.
 
-Evaluation and per-query cost remain separate. `Prog.runM` combines them with `AddWriterT`, so
-effect-dependent control flow produces branch-correlated results and total costs.
+`Prog.evalM` is the primary semantics. Evaluation and per-query cost remain separate in `ModelM`.
+`Prog.runM` records enough operational information to derive the runtime views used for randomized
+algorithms: expected runtime, worst-case runtime over random choices, high-probability runtime, and
+expected runtime conditioned on success. The joint result-cost value is supporting data rather than
+itself a complexity measure; conditioning on success is the reason the correlation must be retained.
+
+Value-correctness reasoning is independent of cost. A model whose semantic monad has a
+`Std.Do.WPMonad` supplies the same `mvcgen` infrastructure as the existing pure `Model` API through
+`ModelM.handler` and `ModelM.hasHandler`. Quantitative PMF reasoning remains a separate future
+layer.
 -/
 
 @[expose] public section
@@ -103,33 +111,6 @@ def sum {Q₂ : Type u → Type x} (M₁ : ModelM Q m Cost) (M₂ : ModelM Q₂ 
     (M₁ : ModelM Q m Cost) (M₂ : ModelM Q₂ m Cost) (q : Q₂ α) :
     (M₁.sum M₂).cost (.inr q) = M₂.cost q := rfl
 
-/-- Sum models with distinct cost types, recording their costs in separate product components. -/
-def compose {Q₂ : Type u → Type x} {Cost₂ : Type u} [Zero Cost] [Zero Cost₂]
-    (M₁ : ModelM Q m Cost) (M₂ : ModelM Q₂ m Cost₂) :
-    ModelM (fun α => Sum (Q α) (Q₂ α)) m (Cost × Cost₂) where
-  evalQuery
-    | .inl q => M₁.evalQuery q
-    | .inr q => M₂.evalQuery q
-  cost
-    | .inl q => (M₁.cost q, 0)
-    | .inr q => (0, M₂.cost q)
-
-@[simp] theorem compose_evalQuery_inl {Q₂ : Type u → Type x} {Cost₂ : Type u}
-    [Zero Cost] [Zero Cost₂] (M₁ : ModelM Q m Cost) (M₂ : ModelM Q₂ m Cost₂) (q : Q α) :
-    (M₁.compose M₂).evalQuery (.inl q) = M₁.evalQuery q := rfl
-
-@[simp] theorem compose_evalQuery_inr {Q₂ : Type u → Type x} {Cost₂ : Type u}
-    [Zero Cost] [Zero Cost₂] (M₁ : ModelM Q m Cost) (M₂ : ModelM Q₂ m Cost₂) (q : Q₂ α) :
-    (M₁.compose M₂).evalQuery (.inr q) = M₂.evalQuery q := rfl
-
-@[simp] theorem compose_cost_inl {Q₂ : Type u → Type x} {Cost₂ : Type u}
-    [Zero Cost] [Zero Cost₂] (M₁ : ModelM Q m Cost) (M₂ : ModelM Q₂ m Cost₂) (q : Q α) :
-    (M₁.compose M₂).cost (.inl q) = (M₁.cost q, 0) := rfl
-
-@[simp] theorem compose_cost_inr {Q₂ : Type u → Type x} {Cost₂ : Type u}
-    [Zero Cost] [Zero Cost₂] (M₁ : ModelM Q m Cost) (M₂ : ModelM Q₂ m Cost₂) (q : Q₂ α) :
-    (M₁.compose M₂).cost (.inr q) = (0, M₂.cost q) := rfl
-
 end ModelM
 
 namespace Prog
@@ -140,12 +121,21 @@ variable {Q : Type u → Type v} {m : Type u → Type w} {Cost : Type u}
 def evalM [Monad m] (P : Prog Q α) (M : ModelM Q m Cost) : m α :=
   P.liftM M.evalQuery
 
-/-- Evaluate a program while accumulating branch-correlated query costs. -/
+/-- Record results and accumulated costs in the same semantic branch.
+
+This is foundational data for runtime analyses, not a chosen notion of randomized complexity.
+Keeping the correlation is necessary for analyses such as expected runtime conditioned on success.
+-/
 def runM [Monad m] [AddZero Cost]
     (P : Prog Q α) (M : ModelM Q m Cost) : AddWriterT Cost m α :=
   P.liftM M.runQuery
 
-/-- The effectful total-cost marginal of `runM`. -/
+/-- The total-runtime marginal of `runM`.
+
+For probabilistic semantics this is the runtime distribution used to derive expected, worst-case,
+and high-probability bounds. Analyses conditioned on the returned result must use `runM` so that
+the result-cost correlation is not discarded.
+-/
 def costM [Monad m] [AddZero Cost]
     (P : Prog Q α) (M : ModelM Q m Cost) : m Cost :=
   (P.runM M).cost
@@ -203,44 +193,55 @@ theorem runM_value [Monad m] [LawfulMonad m] [AddMonoid Cost]
   | pure a => simp
   | liftBind q f ih =>
       simp only [runM_liftBind, evalM_liftBind, AddWriterT.value_bind,
-        ModelM.runQuery, AddWriterT.run_mk]
-      simp [ih]
+        ModelM.runQuery, AddWriterT.run_mk, ih, bind_map_left]
 
 @[simp] theorem costM_pure [Monad m] [LawfulMonad m] [AddZero Cost]
     (a : α) (M : ModelM Q m Cost) :
     costM (pure a : Prog Q α) M = pure 0 := by
   simp [costM]
 
-section DeterministicBridge
+@[simp] theorem costM_liftBind [Monad m] [LawfulMonad m] [AddMonoid Cost]
+    (q : Q α) (f : α → Prog Q β) (M : ModelM Q m Cost) :
+    costM (FreeM.liftBind q f) M =
+      (M.evalQuery q >>= fun a => (M.cost q + ·) <$> costM (f a) M) := by
+  simp [costM, runM, ModelM.runQuery, AddWriterT.cost, AddWriterT.run_bind]
+
+section OfModel
 
 variable {Q : Type u → Type u} {Cost : Type u}
 
-/-- `evalM` under a lifted deterministic model agrees with the existing evaluator. -/
+/-- `evalM` under `ofModel` agrees with the existing evaluator. -/
 theorem evalM_ofModel (P : Prog Q α) (M : Algolean.Algorithms.Model Q Cost) :
     Id.run (P.evalM (ModelM.ofModel M)) = P.eval M := by
   induction P with
   | pure a => rfl
   | liftBind q f ih => exact ih (M.evalQuery q)
 
-/-- `costM` under a lifted deterministic model agrees with existing `Prog.time`. -/
+/-- Under `ofModel`, one query contributes its cost and continues with its evaluated result. -/
+@[simp] theorem costM_ofModel_liftBind [AddMonoid Cost]
+    (q : Q α) (f : α → Prog Q β) (M : Algolean.Algorithms.Model Q Cost) :
+    Id.run (Prog.costM (FreeM.liftBind q f) (ModelM.ofModel M)) =
+      M.cost q + Id.run ((f (M.evalQuery q)).costM (ModelM.ofModel M)) := by
+  rw [costM_liftBind]
+  rfl
+
+/-- `costM` under `ofModel` agrees with existing `Prog.time`. -/
 theorem costM_ofModel [AddMonoid Cost]
     (P : Prog Q α) (M : Algolean.Algorithms.Model Q Cost) :
     Id.run (P.costM (ModelM.ofModel M)) = P.time M := by
   induction P with
-  | pure a => simp [costM, runM, Prog.time]
+  | pure a => simp
   | liftBind q f ih =>
-      change M.cost q + Id.run ((runM (f (M.evalQuery q)) (ModelM.ofModel M)).cost) =
-        M.cost q + Prog.time (f (M.evalQuery q)) M
-      simpa [costM] using
-        congrArg (fun c => M.cost q + c) (ih (M.evalQuery q))
+      rw [costM_ofModel_liftBind, Prog.time_liftBind, ih]
 
-end DeterministicBridge
+end OfModel
 
 section Reduction
 
 variable {Q₁ Q₂ : Type u → Type u}
 
-/-- A syntax-level reduction preserves effectful evaluation when it implements every source query
+
+/-- A reduction preserves effectful evaluation when it implements every source query
 in the target model. The existing `Reduction` structure is sufficient; only its correctness
 criterion changes for effectful models. -/
 theorem reduceProg_evalM [Monad m] [LawfulMonad m]
@@ -254,11 +255,11 @@ theorem reduceProg_evalM [Monad m] [LawfulMonad m]
       simp only [Prog.reduceProg, evalM, FreeM.liftBind_eq, FreeM.bind_eq_bind,
         FreeM.liftM_bind, FreeM.liftM_lift]
       have hq : FreeM.liftM M₂.evalQuery (red.reduce q) = M₁.evalQuery q := by
-        simpa only [evalM] using hCorrect q
+        apply hCorrect
       rw [hq]
       apply congrArg (fun k : _ → m α => M₁.evalQuery q >>= k)
       funext a
-      simpa only [evalM, Prog.reduceProg] using ih a
+      apply ih
 
 /-- The stronger joint criterion preserves results and branch-correlated accumulated costs. -/
 theorem reduceProg_runM [Monad m] [LawfulMonad m] [AddMonoid Cost]
@@ -272,13 +273,71 @@ theorem reduceProg_runM [Monad m] [LawfulMonad m] [AddMonoid Cost]
       simp only [Prog.reduceProg, runM, FreeM.liftBind_eq, FreeM.bind_eq_bind,
         FreeM.liftM_bind, FreeM.liftM_lift]
       have hq : FreeM.liftM M₂.runQuery (red.reduce q) = M₁.runQuery q := by
-        simpa only [runM] using hCorrect q
+        apply hCorrect
       rw [hq]
       apply congrArg (fun k : _ → AddWriterT Cost m α => M₁.runQuery q >>= k)
       funext a
-      simpa only [runM, Prog.reduceProg] using ih a
+      apply ih
 
 end Reduction
 
 end Prog
+
+section WeakestPrecondition
+
+open Cslib.FreeM Std.Do
+
+variable {ps : PostShape.{u}}
+
+namespace ModelM
+
+/-- The logical handler induced by the effectful evaluation semantics of `M`.
+
+The cost field is intentionally absent: ordinary Hoare triples specify value correctness under
+`evalM`. Cost-aware and quantitative probabilistic logics are separate analyses.
+-/
+def handler [WP m ps] (M : ModelM Q m Cost) : LHandler Q ps :=
+  LHandler.ofInterp (m := m) (fun _ q => M.evalQuery q)
+
+/-- Select `M` as the logical interpretation of `Prog Q` in a local or scoped context.
+
+This is a value rather than a global instance because the same query syntax may have both a pure
+`Model` and one or more effectful `ModelM` interpretations.
+-/
+@[reducible] def hasHandler [WP m ps] (M : ModelM Q m Cost) : HasHandler Q ps where
+  handler := M.handler
+
+/-- Weakest-precondition reasoning through `M.handler` agrees with executing the program using
+`Prog.evalM M` whenever the semantic monad has a lawful weakest-precondition interpretation. -/
+theorem wp_eq_wp_evalM [Monad m] [WPMonad m ps]
+    (M : ModelM Q m Cost) (P : Prog Q α) :
+    wpH M.handler P = wp (P.evalM M) := by
+  unfold ModelM.handler Prog.evalM
+  exact wpH_ofInterp_eq_wp_liftM (m := m) (fun _ q => M.evalQuery q) P
+
+end ModelM
+
+/-- Generic single-query rule for the currently selected logical handler.
+
+When the selected handler is `M.hasHandler`, this precondition reduces to
+`wp⟦M.evalQuery q⟧ Q'`. The rule lets `mvcgen` decompose effectful query programs without choosing a
+global `ModelM` for the query language.
+-/
+@[spec]
+theorem Spec.queryM [HasHandler Q ps] (q : Q α) {Q' : PostCond α ps} :
+    Triple (FreeM.lift q : Prog Q α) ((HasHandler.handler q).apply Q') Q' := by
+  apply Triple.of_entails_wp
+  rw [show wp (FreeM.lift q : Prog Q α) =
+    wpH HasHandler.handler (FreeM.lift q) from rfl, wpH_lift]
+
+/-- The `ModelM` query rule stated directly through the semantic monad's weakest precondition. -/
+theorem ModelM.query_spec [Monad m] [WPMonad m ps]
+    (M : ModelM Q m Cost) (q : Q α) {Q' : PostCond α ps} :
+    let _ : HasHandler Q ps := M.hasHandler
+    Triple (FreeM.lift q : Prog Q α) (wp⟦M.evalQuery q⟧ Q') Q' := by
+  letI := M.hasHandler
+  exact Spec.queryM q
+
+end WeakestPrecondition
+
 end Algolean.Algorithms

--- a/Algolean/QueryModel.lean
+++ b/Algolean/QueryModel.lean
@@ -189,6 +189,24 @@ structure Reduction (Q₁ Q₂ : Type u → Type u) where
 abbrev Prog.reduceProg (P : Prog Q₁ α) (red : Reduction Q₁ Q₂) : Prog Q₂ α :=
   P.liftM red.reduce
 
+/-- Interpreting a reduced program is the same as interpreting each source query through its
+reduction. -/
+theorem Prog.reduceProg_liftM {m : Type u → Type w} [Monad m] [LawfulMonad m]
+    (P : Prog Q₁ α) (red : Reduction Q₁ Q₂)
+    (interp₁ : {ι : Type u} → Q₁ ι → m ι)
+    (interp₂ : {ι : Type u} → Q₂ ι → m ι)
+    (hCorrect : ∀ {ι} (q : Q₁ ι), (red.reduce q).liftM interp₂ = interp₁ q) :
+    (P.reduceProg red).liftM interp₂ = P.liftM interp₁ := by
+  induction P with
+  | pure a => rfl
+  | liftBind q f ih =>
+      simp only [reduceProg, FreeM.liftBind_eq, FreeM.bind_eq_bind,
+        FreeM.liftM_bind, FreeM.liftM_lift]
+      rw [hCorrect q]
+      apply congrArg (fun k => interp₁ q >>= k)
+      funext a
+      apply ih
+
 /-- A reduction preserves evaluation when it correctly implements each query. -/
 theorem Prog.reduceProg_eval
     (P : Prog Q₁ α) (red : Reduction Q₁ Q₂)

--- a/AlgoleanTests.lean
+++ b/AlgoleanTests.lean
@@ -3,6 +3,7 @@ module  -- shake: keep-all --deprecated_module: ignore
 public import AlgoleanTests.CircuitExamples
 public import AlgoleanTests.FreeMonadWP
 public import AlgoleanTests.KMPExamples
+public import AlgoleanTests.ModelMWP
 public import AlgoleanTests.NaivePatternSearchExamples
 public import AlgoleanTests.ProgExamples
 public import AlgoleanTests.QueryExamples

--- a/AlgoleanTests.lean
+++ b/AlgoleanTests.lean
@@ -3,6 +3,7 @@ module  -- shake: keep-all --deprecated_module: ignore
 public import AlgoleanTests.CircuitExamples
 public import AlgoleanTests.FreeMonadWP
 public import AlgoleanTests.KMPExamples
+public import AlgoleanTests.ModelM
 public import AlgoleanTests.ModelMWP
 public import AlgoleanTests.NaivePatternSearchExamples
 public import AlgoleanTests.ProgExamples

--- a/AlgoleanTests/FreeMonadWP.lean
+++ b/AlgoleanTests/FreeMonadWP.lean
@@ -13,9 +13,10 @@ public import Std.Tactic.Do
 /-!
 Examples for WP in `Algolean.FreeWP.WP`: instance resolution,
 a `Triple` on a `FreeState` program discharged by `mvcgen`, a custom `CounterF` effect with
-its own logical handler, sum/failure/demonic effects, and — connecting the WP framework to this
-repository's query model — Hoare triples about query-model programs `Prog Q α` against a handler
-derived from a `Model Q Cost` (illustrated on `ReadOnlyVec`).
+its own logical handler, sum/failure/demonic effects, arbitrary relational operation specifications,
+and — connecting the WP framework to this repository's query model — Hoare triples about
+query-model programs `Prog Q α` against a handler derived from a `Model Q Cost` (illustrated on
+`ReadOnlyVec`).
 -/
 
 @[expose] public section
@@ -190,29 +191,16 @@ inductive DemonicF : Type → Type 1 where
   /-- Choose an element of `α`. -/
   | choice (α : Type) : DemonicF α
 
-/-- Logical handler for `DemonicF`: the predicate transformer for `choice α` is universal
-quantification over `α`. Conjunctivity of `∀` (i.e. `∀ a, P a ∧ Q a ⊣⊢ (∀ a, P a) ∧ (∀ a, Q a)`)
-is what makes this admissible in `PredTrans`. -/
-def DemonicF.handler {ps : PostShape} : LHandler DemonicF ps :=
-  fun op => match op with
-    | .choice _ =>
-      { trans := fun Q => SPred.forall (fun a => Q.1 a)
-        conjunctiveRaw := by
-          intro Q₁ Q₂
-          apply SPred.bientails.iff.mpr
-          refine ⟨?_, ?_⟩
-          · apply SPred.and_intro
-            · apply SPred.forall_intro
-              intro a
-              exact (SPred.forall_elim a).trans SPred.and_elim_l
-            · apply SPred.forall_intro
-              intro a
-              exact (SPred.forall_elim a).trans SPred.and_elim_r
-          · apply SPred.forall_intro
-            intro a
-            apply SPred.and_intro
-            · exact SPred.and_elim_l.trans (SPred.forall_elim a)
-            · exact SPred.and_elim_r.trans (SPred.forall_elim a) }
+/-- Relational specification for demonic choice: it is always enabled and every output is
+permitted. The generated weakest precondition must therefore establish the continuation
+postcondition for every possible output. -/
+def DemonicF.spec : OperationSpec DemonicF where
+  pre _ := True
+  post _ _ := True
+
+/-- Logical handler for demonic choice, generated from its relational operation specification. -/
+def DemonicF.handler : LHandler DemonicF .pure :=
+  DemonicF.spec.toHandler
 
 instance : HasHandler DemonicF .pure where
   handler := DemonicF.handler
@@ -224,15 +212,50 @@ abbrev demonic (α : Type) : FreeM DemonicF α := lift (DemonicF.choice α)
 @[spec]
 theorem Spec.demonic {α : Type} {Q : PostCond α .pure} :
     Triple (demonic α) (SPred.forall (fun a : α => Q.1 a)) Q :=
-  Triple.iff.mpr SPred.entails.rfl
+  fun h => ⟨True.intro, fun a _ => h a⟩
 
 /-- A demonic Bool: the precondition must hold for both `true` and `false`. -/
 example {Q : PostCond Bool .pure} :
     Triple (demonic Bool) (SPred.and (Q.1 true) (Q.1 false)) Q :=
-    fun ⟨ht, hf⟩ b =>
-    match b with
-    | true => ht
-    | false => hf
+  fun ⟨ht, hf⟩ => ⟨True.intro, fun
+    | true, _ => ht
+    | false, _ => hf⟩
+
+/-! ### Arbitrarily specified operations -/
+
+/-- An abstract Boolean operation used to reproduce the `pick` example from
+*Dijkstra Monads for All*. -/
+inductive PickF : Type → Type where
+  /-- Pick a Boolean. -/
+  | pick : PickF Bool
+
+/-- `pick` is always enabled and is specified to return only `true`. -/
+def PickF.spec : OperationSpec PickF where
+  pre _ := True
+  post
+    | .pick, b => b = true
+
+/-- Logical handler generated independently of any executable interpretation of `pick`. -/
+def PickF.handler : LHandler PickF .pure :=
+  PickF.spec.toHandler
+
+instance : HasHandler PickF .pure where
+  handler := PickF.handler
+
+/-- Smart constructor for the abstract `pick` operation. -/
+abbrev pick : FreeM PickF Bool := lift PickF.pick
+
+/-- The generated operation WP simplifies to the `true` case of the continuation postcondition. -/
+example (Q : PostCond Bool .pure) :
+    (wpH PickF.handler pick).apply Q = Q.1 true := by
+  rw [wpH_lift]
+  apply SPred.ext_nil
+  simp [PickF.handler, PickF.spec]
+
+/-- Consequently, `pick` has precisely the paper's Hoare specification. -/
+example {Q : PostCond Bool .pure} :
+    Triple pick (Q.1 true) Q :=
+  fun h => ⟨True.intro, fun _ hEq => hEq ▸ h⟩
 
 /-! ### Query-model programs
 

--- a/AlgoleanTests/ModelM.lean
+++ b/AlgoleanTests/ModelM.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2026 Tanner Duve. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tanner Duve
+-/
+
+module
+
+public import Algolean.ModelM
+
+/-!
+# Tests for monadic query models
+
+This file tests branch-dependent cost accumulation and cost-preserving query reductions.
+-/
+
+@[expose] public section
+
+namespace AlgoleanTests.ModelM
+
+open Algolean Algolean.Algorithms Cslib
+
+/-- Queries for a binary choice and a unit-cost step. -/
+inductive ChoiceQ : Type → Type where
+  | choose : ChoiceQ Bool
+  | tick : ChoiceQ Unit
+
+/-- Interpret `ChoiceQ` in the list monad. -/
+def choiceModel : ModelM ChoiceQ List Nat where
+  evalQuery
+    | .choose => [false, true]
+    | .tick => [()]
+  cost _ := 1
+
+/-- Perform an additional query on the `true` branch. -/
+def branch : Prog ChoiceQ Unit := do
+  if ← FreeM.lift .choose then
+    FreeM.lift .tick
+
+example : (branch.runM choiceModel).run = [⟨(), 1⟩, ⟨(), 2⟩] := rfl
+
+example : branch.costM choiceModel = [1, 2] := rfl
+
+/-- A unit-cost state increment. -/
+inductive TickQ : Type → Type where
+  | tick : TickQ Unit
+
+/-- A state increment of two. -/
+inductive DoubleTickQ : Type → Type where
+  | tickTwice : DoubleTickQ Unit
+
+/-- Interpret `TickQ` as a state increment. -/
+def tickModel : ModelM TickQ (StateM Nat) Nat where
+  evalQuery
+    | .tick => modify (· + 1)
+  cost _ := 1
+
+/-- Interpret `DoubleTickQ` as a state increment of two. -/
+def doubleTickModel : ModelM DoubleTickQ (StateM Nat) Nat where
+  evalQuery
+    | .tickTwice => modify (· + 2)
+  cost _ := 2
+
+/-- Implement one double increment using two unit increments. -/
+def doubleTickReduction : Reduction DoubleTickQ TickQ where
+  reduce
+    | .tickTwice => do
+      FreeM.lift .tick
+      FreeM.lift .tick
+
+example (P : Prog DoubleTickQ α) :
+    (P.reduceProg doubleTickReduction).runM tickModel = P.runM doubleTickModel := by
+  apply Prog.reduceProg_runM
+  intro _ q
+  cases q
+  rfl
+
+end AlgoleanTests.ModelM

--- a/AlgoleanTests/ModelMWP.lean
+++ b/AlgoleanTests/ModelMWP.lean
@@ -12,9 +12,7 @@ public import Std.Tactic.Do
 /-!
 # Weakest-precondition reasoning for `ModelM`
 
-Regression coverage showing that an effectful query model inherits `mvcgen` support whenever its
-semantic monad has a `WPMonad` instance. The chosen handler is local, so it cannot conflict with a
-pure `Model` or another effectful interpretation of the same query syntax.
+This file exercises weakest-precondition reasoning and `mvcgen` for a `StateM` query model.
 -/
 
 @[expose] public section
@@ -25,10 +23,12 @@ namespace AlgoleanTests.ModelMWP
 
 open Algolean.Algorithms Cslib Cslib.FreeM Std.Do
 
+/-- Queries for incrementing and reading a counter. -/
 inductive CounterQ : Type → Type where
   | tick : CounterQ Unit
   | read : CounterQ Nat
 
+/-- Interpret counter queries in `StateM Nat`, with unit cost for each query. -/
 def counterModel : ModelM CounterQ (StateM Nat) Nat where
   evalQuery
     | .tick => modify (· + 1)
@@ -37,10 +37,13 @@ def counterModel : ModelM CounterQ (StateM Nat) Nat where
 
 local instance : HasHandler CounterQ (.arg Nat .pure) := counterModel.hasHandler
 
+/-- Increment the counter. -/
 def tick : Prog CounterQ Unit := FreeM.lift .tick
 
+/-- Read the counter. -/
 def read : Prog CounterQ Nat := FreeM.lift .read
 
+/-- Increment the counter and return its new value. -/
 def tickThenRead : Prog CounterQ Nat := do
   tick
   read
@@ -48,6 +51,12 @@ def tickThenRead : Prog CounterQ Nat := do
 example (P : Prog CounterQ α) :
     wpH counterModel.handler P = wp (P.evalM counterModel) :=
   counterModel.wp_eq_wp_evalM P
+
+example {Q : PostCond Nat (.arg Nat .pure)} :
+    let _ : HasHandler CounterQ (.arg Nat .pure) := counterModel.hasHandler
+    Triple (FreeM.lift CounterQ.read : Prog CounterQ Nat)
+      (wp⟦counterModel.evalQuery .read⟧ Q) Q :=
+  counterModel.query_spec .read
 
 example (n : Nat) :
     ⦃fun s => ⌜s = n⌝⦄ tickThenRead

--- a/AlgoleanTests/ModelMWP.lean
+++ b/AlgoleanTests/ModelMWP.lean
@@ -55,8 +55,8 @@ example (P : Prog CounterQ α) :
 example {Q : PostCond Nat (.arg Nat .pure)} :
     let _ : HasHandler CounterQ (.arg Nat .pure) := counterModel.hasHandler
     Triple (FreeM.lift CounterQ.read : Prog CounterQ Nat)
-      (wp⟦counterModel.evalQuery .read⟧ Q) Q :=
-  counterModel.query_spec .read
+      (wp⟦counterModel.evalQuery .read⟧ Q) Q := by
+  mvcgen [counterModel, ModelM.handler]
 
 example (n : Nat) :
     ⦃fun s => ⌜s = n⌝⦄ tickThenRead

--- a/AlgoleanTests/ModelMWP.lean
+++ b/AlgoleanTests/ModelMWP.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 Tanner Duve. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tanner Duve
+-/
+
+module
+
+public import Algolean.ModelM
+public import Std.Tactic.Do
+
+/-!
+# Weakest-precondition reasoning for `ModelM`
+
+Regression coverage showing that an effectful query model inherits `mvcgen` support whenever its
+semantic monad has a `WPMonad` instance. The chosen handler is local, so it cannot conflict with a
+pure `Model` or another effectful interpretation of the same query syntax.
+-/
+
+@[expose] public section
+
+set_option mvcgen.warning false
+
+namespace AlgoleanTests.ModelMWP
+
+open Algolean.Algorithms Cslib Cslib.FreeM Std.Do
+
+inductive CounterQ : Type → Type where
+  | tick : CounterQ Unit
+  | read : CounterQ Nat
+
+def counterModel : ModelM CounterQ (StateM Nat) Nat where
+  evalQuery
+    | .tick => modify (· + 1)
+    | .read => get
+  cost _ := 1
+
+local instance : HasHandler CounterQ (.arg Nat .pure) := counterModel.hasHandler
+
+def tick : Prog CounterQ Unit := FreeM.lift .tick
+
+def read : Prog CounterQ Nat := FreeM.lift .read
+
+def tickThenRead : Prog CounterQ Nat := do
+  tick
+  read
+
+example (P : Prog CounterQ α) :
+    wpH counterModel.handler P = wp (P.evalM counterModel) :=
+  counterModel.wp_eq_wp_evalM P
+
+example (n : Nat) :
+    ⦃fun s => ⌜s = n⌝⦄ tickThenRead
+      ⦃⇓ value s => ⌜value = n + 1 ∧ s = n + 1⌝⦄ := by
+  mvcgen [tickThenRead, tick, read, counterModel, ModelM.handler]
+  subst_vars
+  exact ⟨rfl, rfl⟩
+
+end AlgoleanTests.ModelMWP


### PR DESCRIPTION
`ModelM Q m Cost` interprets each operation in `Q` as a computation in `m` and assigns the operation a cost. `Prog.evalM` extends the operation interpretation to complete `FreeM` programs. `Prog.runM` combines evaluation and cost in `AddWriterT Cost m`, pairing each result with the cost accumulated along the execution that produced it. `Prog.costM` projects the accumulated cost into `m`.

A deterministic `Model` embeds into `ModelM` over `Id`. Models over the same monad and cost type can be combined across sums of query signatures.

`Prog.reduceProg_liftM` lifts an equation between primitive operation handlers to complete programs. `reduceProg_evalM`, `reduceProg_runM`, and `reduceProg_costM` specialize this theorem to evaluation, result-cost semantics, and accumulated costs.

When `m` has a `WPMonad` instance, `ModelM.handler` composes the operation interpretation with the monad's weakest-precondition semantics. `ModelM.query_spec` supplies the corresponding primitive-operation rule to `mvcgen`.