### PR TITLE
Add relational specifications for FreeM operations

### DIFF
--- a/Algolean/FreeWP/WP.lean
+++ b/Algolean/FreeWP/WP.lean
@@ -26,8 +26,16 @@ The WP's structural rules (`wpH_pure`, `wpH_bind`, …) are immediate from `lift
 morphism; the adequacy theorem `wpH_ofInterp_eq_wp_liftM` — that WP-via-handler agrees with
 `Std.Do`'s WP of the `liftM` interpretation — is the same statement of uniqueness.
 
+For pure specifications, an `OperationSpec F` assigns an arbitrary precondition and relational
+postcondition to every operation in `F`. Its `toHandler` method compiles these contracts into
+logical handlers. This is the free-monad construction from Maillard et al.,
+[*Dijkstra Monads for All*][Maillard2019]: because `FreeM F` imposes no equations on operation
+trees, the primitive contracts extend freely to a compositional weakest-precondition semantics.
+
 The design follows [Vistrup, Sammler, Jung. *Program Logics à la Carte.* POPL 2025], adapted
 from coinductive ITrees to inductive `FreeM` and from Iris to `Std.Do`.
+
+[Maillard2019]: https://arxiv.org/abs/1903.01237
 -/
 
 @[expose] public section
@@ -48,6 +56,42 @@ variable {F G : Type u → Type v} {ps : PostShape.{u}} {α β : Type u}
 `PredTrans ps`. -/
 abbrev LHandler (F : Type u → Type v) (ps : PostShape.{u}) : Type (max (u + 1) v) :=
   ∀ {ι : Type u}, F ι → PredTrans ps ι
+
+/-- A relational specification for every operation in an indexed signature `F`.
+
+An operation `op : F ι` packages its operation name and input and returns a value of type `ι`.
+`pre op` must hold before invoking it, while `post op out` characterizes the outputs that the
+operation is allowed to return. Because `FreeM F` is free of equations, these contracts may be
+chosen independently for each operation. -/
+structure OperationSpec (F : Type u → Type v) : Type (max (u + 1) v) where
+  /-- Preconditions for primitive operations. -/
+  pre {ι : Type u} (op : F ι) : Prop
+  /-- Relational postconditions for primitive operations and their outputs. -/
+  post {ι : Type u} (op : F ι) (out : ι) : Prop
+
+namespace OperationSpec
+
+/-- Compile relational operation contracts into a pure logical handler.
+
+For `op : F ι` and a continuation postcondition `Q`, the resulting weakest precondition is
+`S.pre op ∧ ∀ out, S.post op out → Q out`: the operation must be enabled, and every output
+permitted by its relational postcondition must make the continuation safe. -/
+def toHandler (S : OperationSpec F) : LHandler F .pure :=
+  fun op =>
+    { trans := fun Q =>
+        spred(⌜S.pre op ∧ ∀ out, S.post op out → (Q.1 out).down⌝)
+      conjunctiveRaw := by
+        intro Q₁ Q₂
+        aesop }
+
+@[simp]
+theorem apply_toHandler (S : OperationSpec F) {ι : Type u} (op : F ι)
+    (Q : PostCond ι .pure) :
+    (S.toHandler op).apply Q =
+      spred(⌜S.pre op ∧ ∀ out, S.post op out → (Q.1 out).down⌝) :=
+  rfl
+
+end OperationSpec
 
 namespace LHandler
 
@@ -124,6 +168,14 @@ instance instWPFreeM [HasHandler F ps] : WP (FreeM F) ps where
 instance instWPMonadFreeM [HasHandler F ps] : WPMonad (FreeM F) ps where
   wp_pure _ := rfl
   wp_bind x f := wpH_bind _ x f
+
+/-- The generic Hoare rule for a primitive `FreeM` operation. Its precondition is exactly the
+predicate transformer assigned by the selected logical handler. Its low `mvcgen` priority lets
+effect-specific rules expose more useful preconditions when available. -/
+@[spec low]
+theorem Spec.lift_FreeM [HasHandler F ps] (op : F α) {Q : PostCond α ps} :
+    Triple (lift op : FreeM F α) ((HasHandler.handler op).apply Q) Q :=
+  Triple.iff.mpr SPred.entails.rfl
 
 end FreeM
 

--- a/AlgoleanTests/FreeMonadWP.lean
+++ b/AlgoleanTests/FreeMonadWP.lean
@@ -13,9 +13,10 @@ public import Std.Tactic.Do
 /-!
 Examples for WP in `Algolean.FreeWP.WP`: instance resolution,
 a `Triple` on a `FreeState` program discharged by `mvcgen`, a custom `CounterF` effect with
-its own logical handler, sum/failure/demonic effects, and — connecting the WP framework to this
-repository's query model — Hoare triples about query-model programs `Prog Q α` against a handler
-derived from a `Model Q Cost` (illustrated on `ReadOnlyVec`).
+its own logical handler, sum/failure/demonic effects, arbitrary relational operation specifications,
+and — connecting the WP framework to this repository's query model — Hoare triples about
+query-model programs `Prog Q α` against a handler derived from a `Model Q Cost` (illustrated on
+`ReadOnlyVec`).
 -/
 
 @[expose] public section
@@ -190,29 +191,16 @@ inductive DemonicF : Type → Type 1 where
   /-- Choose an element of `α`. -/
   | choice (α : Type) : DemonicF α
 
-/-- Logical handler for `DemonicF`: the predicate transformer for `choice α` is universal
-quantification over `α`. Conjunctivity of `∀` (i.e. `∀ a, P a ∧ Q a ⊣⊢ (∀ a, P a) ∧ (∀ a, Q a)`)
-is what makes this admissible in `PredTrans`. -/
-def DemonicF.handler {ps : PostShape} : LHandler DemonicF ps :=
-  fun op => match op with
-    | .choice _ =>
-      { trans := fun Q => SPred.forall (fun a => Q.1 a)
-        conjunctiveRaw := by
-          intro Q₁ Q₂
-          apply SPred.bientails.iff.mpr
-          refine ⟨?_, ?_⟩
-          · apply SPred.and_intro
-            · apply SPred.forall_intro
-              intro a
-              exact (SPred.forall_elim a).trans SPred.and_elim_l
-            · apply SPred.forall_intro
-              intro a
-              exact (SPred.forall_elim a).trans SPred.and_elim_r
-          · apply SPred.forall_intro
-            intro a
-            apply SPred.and_intro
-            · exact SPred.and_elim_l.trans (SPred.forall_elim a)
-            · exact SPred.and_elim_r.trans (SPred.forall_elim a) }
+/-- Relational specification for demonic choice: it is always enabled and every output is
+permitted. The generated weakest precondition must therefore establish the continuation
+postcondition for every possible output. -/
+def DemonicF.spec : OperationSpec DemonicF where
+  pre _ := True
+  post _ _ := True
+
+/-- Logical handler for demonic choice, generated from its relational operation specification. -/
+def DemonicF.handler : LHandler DemonicF .pure :=
+  DemonicF.spec.toHandler
 
 instance : HasHandler DemonicF .pure where
   handler := DemonicF.handler
@@ -224,15 +212,50 @@ abbrev demonic (α : Type) : FreeM DemonicF α := lift (DemonicF.choice α)
 @[spec]
 theorem Spec.demonic {α : Type} {Q : PostCond α .pure} :
     Triple (demonic α) (SPred.forall (fun a : α => Q.1 a)) Q :=
-  Triple.iff.mpr SPred.entails.rfl
+  fun h => ⟨True.intro, fun a _ => h a⟩
 
 /-- A demonic Bool: the precondition must hold for both `true` and `false`. -/
 example {Q : PostCond Bool .pure} :
     Triple (demonic Bool) (SPred.and (Q.1 true) (Q.1 false)) Q :=
-    fun ⟨ht, hf⟩ b =>
-    match b with
-    | true => ht
-    | false => hf
+  fun ⟨ht, hf⟩ => ⟨True.intro, fun
+    | true, _ => ht
+    | false, _ => hf⟩
+
+/-! ### Arbitrarily specified operations -/
+
+/-- An abstract Boolean operation used to reproduce the `pick` example from
+*Dijkstra Monads for All*. -/
+inductive PickF : Type → Type where
+  /-- Pick a Boolean. -/
+  | pick : PickF Bool
+
+/-- `pick` is always enabled and is specified to return only `true`. -/
+def PickF.spec : OperationSpec PickF where
+  pre _ := True
+  post
+    | .pick, b => b = true
+
+/-- Logical handler generated independently of any executable interpretation of `pick`. -/
+def PickF.handler : LHandler PickF .pure :=
+  PickF.spec.toHandler
+
+instance : HasHandler PickF .pure where
+  handler := PickF.handler
+
+/-- Smart constructor for the abstract `pick` operation. -/
+abbrev pick : FreeM PickF Bool := lift PickF.pick
+
+/-- The generated operation WP simplifies to the `true` case of the continuation postcondition. -/
+example (Q : PostCond Bool .pure) :
+    (wpH PickF.handler pick).apply Q = Q.1 true := by
+  rw [wpH_lift]
+  apply SPred.ext_nil
+  simp [PickF.handler, PickF.spec]
+
+/-- Consequently, `pick` has precisely the paper's Hoare specification. -/
+example {Q : PostCond Bool .pure} :
+    Triple pick (Q.1 true) Q :=
+  fun h => ⟨True.intro, fun _ hEq => hEq ▸ h⟩
 
 /-! ### Query-model programs
 

--- a/AlgoleanTests/FreeMonadWP.lean
+++ b/AlgoleanTests/FreeMonadWP.lean
@@ -239,8 +239,15 @@ def PickF.spec : OperationSpec PickF where
 def PickF.handler : LHandler PickF .pure :=
   PickF.spec.toHandler
 
-instance : HasHandler PickF .pure where
+instance PickF.instHasHandler : HasHandler PickF .pure where
   handler := PickF.handler
+
+/-- The default handler's generated precondition reduces to the `true` branch. -/
+@[simp]
+theorem PickF.apply_defaultHandler (Q : PostCond Bool .pure) :
+    (HasHandler.handler PickF.pick).apply Q = Q.1 true := by
+  apply SPred.ext_nil
+  simp [HasHandler.handler, PickF.handler, PickF.spec]
 
 /-- Smart constructor for the abstract `pick` operation. -/
 abbrev pick : FreeM PickF Bool := lift PickF.pick
@@ -252,10 +259,25 @@ example (Q : PostCond Bool .pure) :
   apply SPred.ext_nil
   simp [PickF.handler, PickF.spec]
 
-/-- Consequently, `pick` has precisely the paper's Hoare specification. -/
-example {Q : PostCond Bool .pure} :
+/-- Consequently, `pick` has precisely the paper's Hoare specification. The rule is derived from
+the generic `FreeM.lift` rule and registered with `mvcgen` for use in larger programs. -/
+@[spec]
+theorem Spec.pick {Q : PostCond Bool .pure} :
     Triple pick (Q.1 true) Q :=
-  fun h => ⟨True.intro, fun _ hEq => hEq ▸ h⟩
+  by
+    simpa only [AlgoleanTests.FreeMonadWP.pick, PickF.apply_defaultHandler] using
+      (Cslib.FreeM.Spec.lift_FreeM PickF.pick (Q := Q))
+
+/-- Two abstract operations compose through the generated handler: `mvcgen` uses the generic
+operation rule derived above and proves that both results satisfy the relational specification. -/
+def pickTwice : FreeM PickF (Bool × Bool) := do
+  let x ← pick
+  let y ← pick
+  pure (x, y)
+
+example :
+    ⦃⌜True⌝⦄ pickTwice ⦃⇓ r => ⌜r = (true, true)⌝⦄ := by
+  mvcgen [pickTwice]
 
 /-! ### Query-model programs
 


### PR DESCRIPTION
`OperationSpec` removes the boilerplate required to turn per-operation pre/post relations into a
`FreeM` weakest-precondition handler.

For `op : F α`, `OperationSpec.toHandler` generates

```text
pre op ∧ ∀ out, post op out → Q out
```

along with the conjunctivity proof required by `PredTrans`.

The PR also adds a low-priority `@[spec]` rule for `FreeM.lift`. The tests use it to derive the
`pick` rule and verify two composed `pick` operations with `mvcgen`.
