### PR TITLE
Add random sampling query models over ModelM

### DIFF
--- a/Algolean/ModelM.lean
+++ b/Algolean/ModelM.lean
@@ -175,6 +175,11 @@ def costM [Monad m] [AddZero Cost]
       (M.evalQuery q >>= fun a => (M.cost q + ·) <$> costM (f a) M) := by
   simp [costM, runM, ModelM.runQuery, AddWriterT.cost, AddWriterT.run_bind]
 
+@[simp] theorem costM_lift [Monad m] [LawfulMonad m] [AddMonoid Cost]
+    (q : Q α) (M : ModelM Q m Cost) :
+    costM (FreeM.lift q) M = (fun _ => M.cost q) <$> M.evalQuery q := by
+  simp [costM]
+
 @[simp] theorem costM_map [Monad m] [LawfulMonad m] [AddMonoid Cost]
     (f : α → β) (P : Prog Q α) (M : ModelM Q m Cost) :
     costM (f <$> P) M = costM P M := by

--- a/Algolean/Models/RandomSample.lean
+++ b/Algolean/Models/RandomSample.lean
@@ -1,66 +1,186 @@
 /-
 Copyright (c) 2026 Shreyas Srinivas. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Shreyas Srinivas
+Authors: Shreyas Srinivas, Tanner Duve
 -/
 
 module
 
-public import Algolean.QueryModel
-public import Mathlib.Probability.ProbabilityMassFunction.Monad
+public import Algolean.ModelM
+public import Mathlib.Probability.ProbabilityMassFunction.Constructions
 
 /-!
-# Query Type for Random Sampling
+# Random sampling query models
 
-A query type for random sampling along with API
-to randomise any query model by composing it with
-`RandomSample`.
+Sampling queries return sampled values to `Prog`; probability appears only in their `PMF`
+interpretation. `RandomSample.sample dist : RandomSample α` carries a distribution in each query.
+The query result is `α`, not `PMF α`; `Prog.evalM` into `PMF` supplies the probabilistic bind that
+explores the possible returned values.
+
+Standard randomized query models treat internal randomness as free: random choices determine which
+costed queries execute but do not themselves contribute query cost. `RandomSample.free` provides
+that interpretation, while `RandomSample.sampleCount` explicitly counts draws when random-sample
+complexity is the quantity of interest.
+
+For a randomized model, `Prog.costM` is the distribution of total query cost from which expected,
+worst-case, and high-probability runtime bounds can be derived. Analyses conditioned on program
+success additionally use `Prog.runM` internally to retain the correlation between a result and its
+cost.
 -/
 
 @[expose] public section
 
-namespace Algolean
+noncomputable section
 
-namespace Algorithms
+/-- `PMF.map_const` at the monad level, stated on the lambda so that `simp` can match it.
 
-/--
-A query type for sampling from distributions on `α`.
-
-Since `Model.evalQuery` is pure, we represent the result of a sampling query by
-the corresponding `PMF α` rather than by a single sampled value.
+Mapping a constant over a distribution discards the randomness entirely; this is what makes
+sampling queries whose results are ignored invisible to cost distributions. The right-hand side
+is the monadic `pure`, written `Pure.pure` because inside the `PMF` namespace a plain `pure`
+denotes `PMF.pure`.
 -/
-inductive RandomSample (α : Type u) : Type u → Type u where
-  | sample : RandomSample α (PMF α)
+@[simp] theorem PMF.map_const' (p : PMF α) (b : β) :
+    (fun _ => b) <$> p = Pure.pure b := by
+  simp only [PMF.monad_map_eq_map, PMF.map, Function.comp_def, PMF.bind_const]
+  rfl
 
-/--
-`RandomizeQuery Q α` extends a query type `Q` with access to a hidden sampling
-oracle on `α`.
+namespace Algolean.Algorithms
 
-The left summand contains the original queries from `Q`, while the right summand
-contains the new sampling query.
+open Cslib Std.Do
+
+/-!
+## Weakest-precondition semantics for `PMF`
+
+A postcondition holds of a `PMF` exactly when it holds of every value in its support. This
+interpretation keeps which results are possible and forgets how likely they are, so a proved
+triple states that the returned value satisfies its postcondition with probability one. That is
+the right notion for algorithms whose answer must be correct on every run. Reasoning about the
+probabilities themselves is quantitative and not captured by these instances.
+
+These instances make every `ModelM Q PMF Cost` interpretation (for example `RandomSample.free`)
+plug into `Std.Do`'s `Triple`/`mvcgen` infrastructure through `ModelM.handler`, just as a
+deterministic `Model` does.
 -/
-abbrev RandomizeQuery (Q : Type u → Type v) (α : Type u) : Type u → Type (max u v) :=
-  fun β => Sum (Q β) (RandomSample α β)
 
-/-- A model of `RandomSample` that counts each sampling query with unit cost. -/
-@[simps]
-def RandomSample.natCost (dist : PMF α) : Model (RandomSample α) ℕ where
+/-- Support-based weakest-precondition interpretation of a `PMF`. -/
+instance instWPPMF : WP PMF .pure where
+  wp x :=
+    { trans := fun Q => ⟨∀ a ∈ x.support, (Q.1 a).down⟩
+      conjunctiveRaw := by
+        intro Q₁ Q₂
+        simp only [SPred.bientails_nil, SPred.and_nil]
+        grind }
+
+/-- The support interpretation is a monad morphism, so `mvcgen` reasoning applies. -/
+instance instWPMonadPMF : WPMonad PMF .pure where
+  wp_pure a := by
+    apply PredTrans.ext
+    intro Q
+    have hp : (pure a : PMF _) = PMF.pure a := rfl
+    rw [hp, PredTrans.apply_Pure_pure]
+    apply ULift.ext
+    simp only [WP.wp, PredTrans.apply, PMF.mem_support_pure_iff, forall_eq]
+  wp_bind x f := by
+    apply PredTrans.ext
+    intro Q
+    have hxf : (x >>= f) = x.bind f := rfl
+    rw [hxf, PredTrans.apply_Bind_bind]
+    apply ULift.ext
+    simp only [WP.wp, PredTrans.apply, PMF.mem_support_bind_iff]
+    grind
+
+/-- Sample from a distribution supplied by this query. -/
+inductive RandomSample : Type u → Type u where
+  | sample (dist : PMF α) : RandomSample α
+
+namespace RandomSample
+
+/-- Lift a distribution-carrying sampling query into a program. -/
+def draw (dist : PMF α) : Prog RandomSample α :=
+  FreeM.lift (.sample dist)
+
+/-- PMF semantics with a caller-chosen cost for each draw. -/
+def model (sampleCost : Cost) : ModelM RandomSample PMF Cost where
   evalQuery
-    | .sample => dist
-  cost _ := 1
+    | .sample dist => dist
+  cost _ := sampleCost
 
-/-- Combine a model for `Q` with a sampling model to interpret `RandomizeQuery Q α`. -/
-@[simps]
-def RandomizeQuery.model (M : Model Q Cost) (S : Model (RandomSample α) Cost) :
-    Model (RandomizeQuery Q α) Cost where
-  evalQuery
-    | .inl q => M.evalQuery q
-    | .inr q => S.evalQuery q
-  cost
-    | .inl q => M.cost q
-    | .inr q => S.cost q
+@[simp] theorem model_evalQuery_sample (sampleCost : Cost) (dist : PMF α) :
+    (model sampleCost).evalQuery (.sample dist) = dist := rfl
 
+@[simp] theorem model_cost (sampleCost : Cost) (q : RandomSample α) :
+    (model sampleCost).cost q = sampleCost := rfl
 
-end Algorithms
+/-- Standard randomized-query semantics in which internal sampling is free. -/
+abbrev free [Zero Cost] : ModelM RandomSample PMF Cost :=
+  model 0
 
-end Algolean
+/-- Random-sample complexity semantics in which every draw contributes one. -/
+abbrev sampleCount : ModelM RandomSample PMF ℕ :=
+  model 1
+
+@[simp] theorem evalM_draw (dist : PMF α) (sampleCost : Cost) :
+    (draw dist).evalM (model sampleCost) = dist := by
+  simp [draw]
+
+@[simp] theorem costM_draw [AddMonoid Cost] (dist : PMF α) (sampleCost : Cost) :
+    (draw dist).costM (model sampleCost) = pure sampleCost := by
+  simp [draw]
+
+end RandomSample
+
+/-- Add distribution-carrying sampling queries to another query language. -/
+abbrev RandomizeQuery (Q : Type u → Type v) : Type u → Type (max u v) :=
+  fun α => Sum (Q α) (RandomSample α)
+
+namespace RandomizeQuery
+
+/-- Lift an original `Q` query into the randomized query language. -/
+def query (q : Q α) : Prog (RandomizeQuery Q) α :=
+  FreeM.lift (.inl q)
+
+/-- Draw from a distribution inside the randomized query language. -/
+def draw (dist : PMF α) : Prog (RandomizeQuery Q) α :=
+  FreeM.lift (.inr (.sample dist))
+
+@[simp] theorem evalM_query [Monad m] [LawfulMonad m]
+    (M : ModelM (RandomizeQuery Q) m Cost) (q : Q α) :
+    (query q).evalM M = M.evalQuery (.inl q) := by
+  simp [query]
+
+@[simp] theorem evalM_draw [Monad m] [LawfulMonad m]
+    (M : ModelM (RandomizeQuery Q) m Cost) (dist : PMF α) :
+    (draw dist).evalM M = M.evalQuery (.inr (.sample dist)) := by
+  simp [draw]
+
+end RandomizeQuery
+
+/-- A `Q` model extended with internal randomness and interpreted probabilistically. -/
+abbrev RandomizeModel (Q : Type u → Type v) (Cost : Type u) :=
+  ModelM (RandomizeQuery Q) PMF Cost
+
+namespace RandomizeModel
+
+/-- Add free internal randomness to a model already interpreted in `PMF`. -/
+abbrev ofModelM [Zero Cost] (M : ModelM Q PMF Cost) : RandomizeModel Q Cost :=
+  M.sum RandomSample.free
+
+/-- Lift a deterministic model into `PMF` and add free internal randomness.
+
+This is the standard randomized-query construction: the original queries retain their costs while
+random choices only determine which queries execute.
+-/
+abbrev ofModel [Zero Cost] (M : Model Q Cost) : RandomizeModel Q Cost :=
+  ofModelM
+    { evalQuery := fun q => PMF.pure (M.evalQuery q)
+      cost := M.cost }
+
+end RandomizeModel
+
+/-- A `HasModel` on `Q` induces a handler on `RandomizeQuery Q` in which `Q` queries follow
+their model and draws are free. -/
+noncomputable instance instHasHandlerRandomizeQuery [HasModel Q Cost] [Zero Cost] :
+    Cslib.FreeM.HasHandler (RandomizeQuery Q) .pure :=
+  (RandomizeModel.ofModel (HasModel.model : Model Q Cost)).hasHandler
+
+end Algolean.Algorithms

--- a/AlgoleanTests.lean
+++ b/AlgoleanTests.lean
@@ -8,3 +8,4 @@ public import AlgoleanTests.ModelMWP
 public import AlgoleanTests.NaivePatternSearchExamples
 public import AlgoleanTests.ProgExamples
 public import AlgoleanTests.QueryExamples
+public import AlgoleanTests.RandomSampleExamples

--- a/AlgoleanTests/RandomSampleExamples.lean
+++ b/AlgoleanTests/RandomSampleExamples.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2026 Tanner Duve. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tanner Duve
+-/
+
+module
+
+public import Algolean.Models.RandomSample
+
+/-!
+# Random sampling examples
+
+Sanity checks for the `RandomSample` query language and its `PMF` models. The examples confirm
+that the `model` simp lemmas apply to `free` and `sampleCount` and that the `RandomizeModel`
+constructions compute by `simp`.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+namespace AlgoleanTests.RandomSampleExamples
+
+open Algolean.Algorithms Cslib RandomSample Std.Do
+
+example (dist : PMF ℕ) : (draw dist).evalM (free (Cost := ℕ)) = dist := by
+  simp
+
+example (dist : PMF ℕ) : (draw dist).costM (free (Cost := ℕ)) = pure 0 := by
+  simp
+
+example (dist : PMF ℕ) : (draw dist).costM sampleCount = pure 1 := by
+  simp
+
+example (M : ModelM Q PMF Cost) [Zero Cost] (q : Q α) :
+    (RandomizeQuery.query q).evalM (RandomizeModel.ofModelM M) = M.evalQuery q := by
+  simp
+
+example (M : ModelM Q PMF Cost) [Zero Cost] (dist : PMF α) :
+    (RandomizeQuery.draw dist).evalM (RandomizeModel.ofModelM M) = dist := by
+  simp
+
+example (M : Model Q Cost) [Zero Cost] (q : Q α) :
+    (RandomizeQuery.query q).evalM (RandomizeModel.ofModel M) = PMF.pure (M.evalQuery q) := by
+  simp
+
+/-- One branch stops after one draw while the other performs a second draw. -/
+def branchWithExtraDraw (coin : PMF Bool) (extra : PMF α) : Prog RandomSample Bool := do
+  let b ← draw coin
+  if b then
+    return true
+  else
+    let _ ← draw extra
+    return false
+
+/-- The sample-count distribution is one draw on the `true` branch and two on the `false` branch.
+
+The values drawn from `extra` do not affect the count; only the fact that the second draw occurs
+matters. This theorem concerns random-sample complexity, not standard randomized query runtime.
+-/
+theorem costM_branchWithExtraDraw (coin : PMF Bool) (extra : PMF α) :
+    (branchWithExtraDraw coin extra).costM sampleCount =
+      (fun b => if b then 1 else 2) <$> coin := by
+  simp only [branchWithExtraDraw, draw, Prog.costM_liftBind,
+    model_evalQuery_sample, model_cost]
+  rw [← bind_pure_comp]
+  apply bind_congr
+  intro b
+  cases b <;> simp
+
+-- Almost-sure reasoning through the support interpretation. `mvcgen` discharges the triple that a
+-- drawn value always lies in the distribution's support, using `free`'s handler as the selected
+-- interpretation of the query language.
+set_option mvcgen.warning false in
+example {α : Type} (dist : PMF α) :
+    letI := (free (Cost := ℕ)).hasHandler
+    ⦃⌜True⌝⦄ draw dist ⦃⇓ a => ⌜a ∈ dist.support⌝⦄ := by
+  letI := (free (Cost := ℕ)).hasHandler
+  mvcgen [draw]
+  exact fun a ha => ha
+
+end AlgoleanTests.RandomSampleExamples


### PR DESCRIPTION
This PR introduces a query language for random sampling, interpreted through the monadic query models from #77. A `RandomSample` query carries a distribution and returns a sampled value, so programs can branch on random results. `Prog.evalM` into `PMF` gives the distribution over a program's results and `Prog.costM` gives the distribution of its total query cost. This replaces the previous representation, where a sampling query returned the `PMF` itself as a value under a pure `Model`.

`RandomSample.model` assigns a caller-chosen cost to each draw. `free` treats internal randomness as free, which is the standard randomized query model, and `sampleCount` counts draws for sample complexity. Both are abbreviations of `model`, so its two simp lemmas cover all three. `RandomizeQuery` and `RandomizeModel` extend an existing query language and its model with free internal randomness, and a `HasModel` instance on the base queries gives the randomized language a default handler.

The PR also gives `PMF` a support-based weakest precondition semantics. A postcondition holds exactly when it holds of every value in the support, so triples proved through `mvcgen` state almost-sure correctness of randomized programs, and any `ModelM` into `PMF` plugs into this through `ModelM.handler`.

Finally, `costM_lift` joins the `ModelM` cost lemmas and `PMF.map_const'` restates Mathlib's `PMF.map_const` at the monad level, which together make cost distributions of sampling programs compute by `simp`. `AlgoleanTests/RandomSampleExamples.lean` checks the simp API, proves the sample count distribution of a program that draws once or twice depending on a coin flip, and derives an almost-sure triple by `mvcgen`.