### PR TITLE
Add randomized quicksort and prove it sorts

### DIFF
--- a/Algolean.lean
+++ b/Algolean.lean
@@ -10,6 +10,7 @@ public import Algolean.Algorithms.ListLinearSearch
 public import Algolean.Algorithms.ListOrderedInsert
 public import Algolean.Algorithms.MergeSort
 public import Algolean.Algorithms.NaivePatternSearch
+public import Algolean.Algorithms.RandomQuicksort
 public import Algolean.Algorithms.VecBubbleSort
 public import Algolean.Algorithms.VecSearch
 public import Algolean.Complexity.Basic

--- a/Algolean/Algorithms/RandomQuicksort.lean
+++ b/Algolean/Algorithms/RandomQuicksort.lean
@@ -1,0 +1,182 @@
+/-
+Copyright (c) 2026 Tanner Duve (Logical Intelligence). All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tanner Duve
+-/
+module
+
+public import Algolean.Models.ListComparisonSort
+public import Algolean.Models.RandomSample
+public import Mathlib.Probability.Distributions.Uniform
+
+/-!
+# Randomized quicksort of a list
+
+This file defines randomized quicksort in the comparison-query model and proves that it always
+returns a sorted permutation of its input. The proof is by `mvcgen` through the support-based
+weakest-precondition semantics of `PMF`.
+
+## Main definitions
+
+- `randomQuicksort`: randomized quicksort in the `SortOps` query model.
+
+## Main results
+
+- `randomQuicksort_spec`: randomized quicksort returns a sorted permutation.
+-/
+
+@[expose] public section
+
+namespace Algolean
+
+namespace Algorithms
+
+namespace Models
+
+open SortOps Std.Do
+
+/-- Keep the elements of `xs` whose corresponding flag in `bs` is `true`. -/
+def keepFlagged (xs : List α) (bs : List Bool) : List α :=
+  ((xs.zip bs).filter (·.2)).map Prod.fst
+
+theorem keepFlagged_length_le (xs : List α) (bs : List Bool) :
+    (keepFlagged xs bs).length ≤ xs.length :=
+  calc (keepFlagged xs bs).length
+      = ((xs.zip bs).filter (·.2)).length := by rw [keepFlagged, List.length_map]
+    _ ≤ (xs.zip bs).length := List.length_filter_le _ _
+    _ ≤ xs.length := by rw [List.length_zip]; exact Nat.min_le_left _ _
+
+/-- Draw a pivot uniformly, partition the rest by comparison against it, sort each side. -/
+noncomputable def randomQuicksort (l : List α) :
+    Prog (RandomizeQuery (SortOps α)) (List α) :=
+  match l with
+  | [] => pure []
+  | x :: xs => do
+    let r ← RandomizeQuery.draw (PMF.uniformOfFintype (Fin (xs.length + 1)))
+    let pivot := (x :: xs).get r
+    let rest := (x :: xs).eraseIdx r
+    let flags ← rest.mapM (fun y ↦ RandomizeQuery.query (SortOps.cmpLE y pivot))
+    let lt := keepFlagged rest flags
+    let rt := keepFlagged rest (flags.map (!·))
+    let sortedlt ← randomQuicksort lt
+    let sortedrt ← randomQuicksort rt
+    pure (sortedlt ++ [pivot] ++ sortedrt)
+termination_by l.length
+decreasing_by
+  all_goals
+    calc _ ≤ rest.length := keepFlagged_length_le _ _
+      _ = xs.length := by simp [rest, List.length_eraseIdx, r.isLt]
+      _ < (x :: xs).length := by simp
+
+section Correctness
+
+variable {α : Type}
+
+/-- The order relation `x ≤ y` under `[Ord α]`. -/
+local notation:50 a:51 " ≼ " b:51 => Ordering.isLE (compare a b) = true
+
+set_option mvcgen.warning false in
+/-- A comparison query returns whether `y ≤ p` under the `Ord` model. -/
+theorem query_cmpLE_spec [Ord α] (y p : α) :
+    ⦃⌜True⌝⦄
+      (RandomizeQuery.query (SortOps.cmpLE y p) : Prog (RandomizeQuery (SortOps α)) Bool)
+      ⦃⇓ b => ⌜b = (compare y p).isLE⌝⦄ := by
+  mvcgen [RandomizeQuery.query]
+  intro b hb
+  exact (PMF.mem_support_pure_iff ((compare y p).isLE) b).mp hb
+
+set_option mvcgen.warning false in
+/-- Comparing every element of `xs` against `p` yields the flags `xs.map (compare · p |>.isLE)`. -/
+theorem mapM_cmpLE_spec [Ord α] (p : α) (xs : List α) :
+    ⦃⌜True⌝⦄ (xs.mapM (fun y ↦ RandomizeQuery.query (SortOps.cmpLE y p))
+        : Prog (RandomizeQuery (SortOps α)) (List Bool))
+      ⦃⇓ flags => ⌜flags = xs.map (fun y ↦ (compare y p).isLE)⌝⦄ := by
+  induction xs with
+  | nil => mvcgen
+  | cons a as ih =>
+    rw [List.mapM_cons]
+    mvcgen [query_cmpLE_spec, ih]
+    simp_all
+
+/-- Keeping the elements flagged by `xs.map g` is filtering by `g`. -/
+private lemma keepFlagged_map (g : α → Bool) (xs : List α) :
+    keepFlagged xs (xs.map g) = xs.filter g := by
+  unfold keepFlagged
+  induction xs with
+  | nil => rfl
+  | cons a as ih =>
+    simp only [List.map_cons, List.zip_cons_cons, List.filter_cons]
+    cases hg : g a <;> simp_all
+
+/-- Gluing `sl`, `sr` (permutations of the two filter-partitions of `rest`) around `pivot` gives a
+permutation of `pivot :: rest`. -/
+private lemma partition_glue_perm (pivot : α) (g : α → Bool) (rest sl sr : List α)
+    (hslp : sl.Perm (rest.filter g)) (hsrp : sr.Perm (rest.filter (fun y ↦ !g y))) :
+    (sl ++ [pivot] ++ sr).Perm (pivot :: rest) := by
+  have h3 :
+      (rest.filter g ++ [pivot] ++ rest.filter (fun y ↦ !g y)).Perm (pivot :: rest) := by
+    rw [List.append_assoc]
+    exact List.perm_middle.trans ((List.filter_append_perm g rest).cons pivot)
+  exact (((hslp.append_right [pivot]).append_right sr).trans
+    (List.Perm.append_left _ hsrp)).trans h3
+
+/-- The glued list is sorted: each half is sorted and lies on its side of the pivot. -/
+private lemma sorted_glue [Ord α] [Std.TransCmp (compare : α → α → Ordering)]
+    (pivot : α) (rest sl sr : List α)
+    (hslp : sl.Perm (rest.filter (fun y ↦ (compare y pivot).isLE)))
+    (hsls : sl.Pairwise (· ≼ ·))
+    (hsrp : sr.Perm (rest.filter (fun y ↦ !(compare y pivot).isLE)))
+    (hsrs : sr.Pairwise (· ≼ ·)) :
+    (sl ++ [pivot] ++ sr).Pairwise (· ≼ ·) := by
+  have hle : ∀ a ∈ sl, a ≼ pivot :=
+    fun a ha ↦ (List.mem_filter.mp (hslp.mem_iff.mp ha)).2
+  have hge : ∀ b ∈ sr, pivot ≼ b := by
+    intro b hb
+    have h2 := (List.mem_filter.mp (hsrp.mem_iff.mp hb)).2
+    rw [(Std.OrientedCmp.eq_swap : compare pivot b = _)]
+    cases h : compare b pivot <;> simp_all [Ordering.swap, Ordering.isLE]
+  have hcross : ∀ a ∈ sl, ∀ c ∈ pivot :: sr, a ≼ c := by
+    intro a ha c hc
+    cases List.mem_cons.mp hc with
+    | inl h => exact h ▸ hle a ha
+    | inr h => exact Std.TransCmp.isLE_trans (hle a ha) (hge c h)
+  rw [List.append_assoc, List.singleton_append, List.pairwise_append]
+  exact ⟨hsls, List.pairwise_cons.mpr ⟨hge, hsrs⟩, hcross⟩
+
+/-- The glued list is a sorted permutation of `pivot :: rest`. -/
+private lemma quicksort_combine [Ord α] [Std.TransCmp (compare : α → α → Ordering)]
+    (pivot : α) (rest sl sr : List α)
+    (hslp : sl.Perm (rest.filter (fun y ↦ (compare y pivot).isLE)))
+    (hsls : sl.Pairwise (· ≼ ·))
+    (hsrp : sr.Perm (rest.filter (fun y ↦ !(compare y pivot).isLE)))
+    (hsrs : sr.Pairwise (· ≼ ·)) :
+    (sl ++ [pivot] ++ sr).Perm (pivot :: rest) ∧ (sl ++ [pivot] ++ sr).Pairwise (· ≼ ·) :=
+  ⟨partition_glue_perm pivot _ rest sl sr hslp hsrp,
+    sorted_glue pivot rest sl sr hslp hsls hsrp hsrs⟩
+
+set_option mvcgen.warning false in
+/-- Randomized quicksort always returns a sorted permutation of its input. -/
+theorem randomQuicksort_spec [Ord α] [Std.TransCmp (compare : α → α → Ordering)]
+    (l : List α) :
+    ⦃⌜True⌝⦄ randomQuicksort l
+      ⦃⇓ out => ⌜out.Perm l ∧ out.Pairwise (· ≼ ·)⌝⦄ := by
+  fun_induction randomQuicksort l
+  next => mvcgen; exact ⟨.refl _, .nil⟩
+  next x xs ih_lt ih_rt =>
+    mvcgen [RandomizeQuery.draw]
+    intro r _hr
+    mvcgen [mapM_cmpLE_spec, ih_lt, ih_rt]
+    rename_i flags hflags sl hsl sr hsr
+    subst hflags
+    simp only [keepFlagged_map, List.map_map, Function.comp_def] at hsl hsr
+    have hc := quicksort_combine ((x :: xs).get r) ((x :: xs).eraseIdx ↑r) sl sr
+      hsl.1 hsl.2 hsr.1 hsr.2
+    exact ⟨hc.1.trans (List.getElem_cons_eraseIdx_perm r.isLt), hc.2⟩
+
+end Correctness
+
+end Models
+
+end Algorithms
+
+end Algolean

--- a/Algolean/ModelM.lean
+++ b/Algolean/ModelM.lean
@@ -175,6 +175,11 @@ def costM [Monad m] [AddZero Cost]
       (M.evalQuery q >>= fun a => (M.cost q + ·) <$> costM (f a) M) := by
   simp [costM, runM, ModelM.runQuery, AddWriterT.cost, AddWriterT.run_bind]
 
+@[simp] theorem costM_lift [Monad m] [LawfulMonad m] [AddMonoid Cost]
+    (q : Q α) (M : ModelM Q m Cost) :
+    costM (FreeM.lift q) M = (fun _ => M.cost q) <$> M.evalQuery q := by
+  simp [costM]
+
 @[simp] theorem costM_map [Monad m] [LawfulMonad m] [AddMonoid Cost]
     (f : α → β) (P : Prog Q α) (M : ModelM Q m Cost) :
     costM (f <$> P) M = costM P M := by

--- a/Algolean/Models/ListComparisonSort.lean
+++ b/Algolean/Models/ListComparisonSort.lean
@@ -148,6 +148,9 @@ def sortModelNat {α : Type*}
     | .cmpLE x y => le x y
   cost _ := 1
 
+/-- The canonical `SortOps` model, interpreting `cmpLE x y` as `x ≤ y` under `[Ord α]`. -/
+instance [Ord α] : HasModel (SortOps α) ℕ := ⟨sortModelNat (fun a b => (compare a b).isLE)⟩
+
 end NatModel
 
 section SortStability

--- a/Algolean/Models/RandomSample.lean
+++ b/Algolean/Models/RandomSample.lean
@@ -1,66 +1,186 @@
 /-
 Copyright (c) 2026 Shreyas Srinivas. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Shreyas Srinivas
+Authors: Shreyas Srinivas, Tanner Duve
 -/
 
 module
 
-public import Algolean.QueryModel
-public import Mathlib.Probability.ProbabilityMassFunction.Monad
+public import Algolean.ModelM
+public import Mathlib.Probability.ProbabilityMassFunction.Constructions
 
 /-!
-# Query Type for Random Sampling
+# Random sampling query models
 
-A query type for random sampling along with API
-to randomise any query model by composing it with
-`RandomSample`.
+Sampling queries return sampled values to `Prog`; probability appears only in their `PMF`
+interpretation. `RandomSample.sample dist : RandomSample α` carries a distribution in each query.
+The query result is `α`, not `PMF α`; `Prog.evalM` into `PMF` supplies the probabilistic bind that
+explores the possible returned values.
+
+Standard randomized query models treat internal randomness as free: random choices determine which
+costed queries execute but do not themselves contribute query cost. `RandomSample.free` provides
+that interpretation, while `RandomSample.sampleCount` explicitly counts draws when random-sample
+complexity is the quantity of interest.
+
+For a randomized model, `Prog.costM` is the distribution of total query cost from which expected,
+worst-case, and high-probability runtime bounds can be derived. Analyses conditioned on program
+success additionally use `Prog.runM` internally to retain the correlation between a result and its
+cost.
 -/
 
 @[expose] public section
 
-namespace Algolean
+noncomputable section
 
-namespace Algorithms
+/-- `PMF.map_const` at the monad level, stated on the lambda so that `simp` can match it.
 
-/--
-A query type for sampling from distributions on `α`.
-
-Since `Model.evalQuery` is pure, we represent the result of a sampling query by
-the corresponding `PMF α` rather than by a single sampled value.
+Mapping a constant over a distribution discards the randomness entirely; this is what makes
+sampling queries whose results are ignored invisible to cost distributions. The right-hand side
+is the monadic `pure`, written `Pure.pure` because inside the `PMF` namespace a plain `pure`
+denotes `PMF.pure`.
 -/
-inductive RandomSample (α : Type u) : Type u → Type u where
-  | sample : RandomSample α (PMF α)
+@[simp] theorem PMF.map_const' (p : PMF α) (b : β) :
+    (fun _ => b) <$> p = Pure.pure b := by
+  simp only [PMF.monad_map_eq_map, PMF.map, Function.comp_def, PMF.bind_const]
+  rfl
 
-/--
-`RandomizeQuery Q α` extends a query type `Q` with access to a hidden sampling
-oracle on `α`.
+namespace Algolean.Algorithms
 
-The left summand contains the original queries from `Q`, while the right summand
-contains the new sampling query.
+open Cslib Std.Do
+
+/-!
+## Weakest-precondition semantics for `PMF`
+
+A postcondition holds of a `PMF` exactly when it holds of every value in its support. This
+interpretation keeps which results are possible and forgets how likely they are, so a proved
+triple states that the returned value satisfies its postcondition with probability one. That is
+the right notion for algorithms whose answer must be correct on every run. Reasoning about the
+probabilities themselves is quantitative and not captured by these instances.
+
+These instances make every `ModelM Q PMF Cost` interpretation (for example `RandomSample.free`)
+plug into `Std.Do`'s `Triple`/`mvcgen` infrastructure through `ModelM.handler`, just as a
+deterministic `Model` does.
 -/
-abbrev RandomizeQuery (Q : Type u → Type v) (α : Type u) : Type u → Type (max u v) :=
-  fun β => Sum (Q β) (RandomSample α β)
 
-/-- A model of `RandomSample` that counts each sampling query with unit cost. -/
-@[simps]
-def RandomSample.natCost (dist : PMF α) : Model (RandomSample α) ℕ where
+/-- Support-based weakest-precondition interpretation of a `PMF`. -/
+instance instWPPMF : WP PMF .pure where
+  wp x :=
+    { trans := fun Q => ⟨∀ a ∈ x.support, (Q.1 a).down⟩
+      conjunctiveRaw := by
+        intro Q₁ Q₂
+        simp only [SPred.bientails_nil, SPred.and_nil]
+        grind }
+
+/-- The support interpretation is a monad morphism, so `mvcgen` reasoning applies. -/
+instance instWPMonadPMF : WPMonad PMF .pure where
+  wp_pure a := by
+    apply PredTrans.ext
+    intro Q
+    have hp : (pure a : PMF _) = PMF.pure a := rfl
+    rw [hp, PredTrans.apply_Pure_pure]
+    apply ULift.ext
+    simp only [WP.wp, PredTrans.apply, PMF.mem_support_pure_iff, forall_eq]
+  wp_bind x f := by
+    apply PredTrans.ext
+    intro Q
+    have hxf : (x >>= f) = x.bind f := rfl
+    rw [hxf, PredTrans.apply_Bind_bind]
+    apply ULift.ext
+    simp only [WP.wp, PredTrans.apply, PMF.mem_support_bind_iff]
+    grind
+
+/-- Sample from a distribution supplied by this query. -/
+inductive RandomSample : Type u → Type u where
+  | sample (dist : PMF α) : RandomSample α
+
+namespace RandomSample
+
+/-- Lift a distribution-carrying sampling query into a program. -/
+def draw (dist : PMF α) : Prog RandomSample α :=
+  FreeM.lift (.sample dist)
+
+/-- PMF semantics with a caller-chosen cost for each draw. -/
+def model (sampleCost : Cost) : ModelM RandomSample PMF Cost where
   evalQuery
-    | .sample => dist
-  cost _ := 1
+    | .sample dist => dist
+  cost _ := sampleCost
 
-/-- Combine a model for `Q` with a sampling model to interpret `RandomizeQuery Q α`. -/
-@[simps]
-def RandomizeQuery.model (M : Model Q Cost) (S : Model (RandomSample α) Cost) :
-    Model (RandomizeQuery Q α) Cost where
-  evalQuery
-    | .inl q => M.evalQuery q
-    | .inr q => S.evalQuery q
-  cost
-    | .inl q => M.cost q
-    | .inr q => S.cost q
+@[simp] theorem model_evalQuery_sample (sampleCost : Cost) (dist : PMF α) :
+    (model sampleCost).evalQuery (.sample dist) = dist := rfl
 
+@[simp] theorem model_cost (sampleCost : Cost) (q : RandomSample α) :
+    (model sampleCost).cost q = sampleCost := rfl
 
-end Algorithms
+/-- Standard randomized-query semantics in which internal sampling is free. -/
+abbrev free [Zero Cost] : ModelM RandomSample PMF Cost :=
+  model 0
 
-end Algolean
+/-- Random-sample complexity semantics in which every draw contributes one. -/
+abbrev sampleCount : ModelM RandomSample PMF ℕ :=
+  model 1
+
+@[simp] theorem evalM_draw (dist : PMF α) (sampleCost : Cost) :
+    (draw dist).evalM (model sampleCost) = dist := by
+  simp [draw]
+
+@[simp] theorem costM_draw [AddMonoid Cost] (dist : PMF α) (sampleCost : Cost) :
+    (draw dist).costM (model sampleCost) = pure sampleCost := by
+  simp [draw]
+
+end RandomSample
+
+/-- Add distribution-carrying sampling queries to another query language. -/
+abbrev RandomizeQuery (Q : Type u → Type v) : Type u → Type (max u v) :=
+  fun α => Sum (Q α) (RandomSample α)
+
+namespace RandomizeQuery
+
+/-- Lift an original `Q` query into the randomized query language. -/
+def query (q : Q α) : Prog (RandomizeQuery Q) α :=
+  FreeM.lift (.inl q)
+
+/-- Draw from a distribution inside the randomized query language. -/
+def draw (dist : PMF α) : Prog (RandomizeQuery Q) α :=
+  FreeM.lift (.inr (.sample dist))
+
+@[simp] theorem evalM_query [Monad m] [LawfulMonad m]
+    (M : ModelM (RandomizeQuery Q) m Cost) (q : Q α) :
+    (query q).evalM M = M.evalQuery (.inl q) := by
+  simp [query]
+
+@[simp] theorem evalM_draw [Monad m] [LawfulMonad m]
+    (M : ModelM (RandomizeQuery Q) m Cost) (dist : PMF α) :
+    (draw dist).evalM M = M.evalQuery (.inr (.sample dist)) := by
+  simp [draw]
+
+end RandomizeQuery
+
+/-- A `Q` model extended with internal randomness and interpreted probabilistically. -/
+abbrev RandomizeModel (Q : Type u → Type v) (Cost : Type u) :=
+  ModelM (RandomizeQuery Q) PMF Cost
+
+namespace RandomizeModel
+
+/-- Add free internal randomness to a model already interpreted in `PMF`. -/
+abbrev ofModelM [Zero Cost] (M : ModelM Q PMF Cost) : RandomizeModel Q Cost :=
+  M.sum RandomSample.free
+
+/-- Lift a deterministic model into `PMF` and add free internal randomness.
+
+This is the standard randomized-query construction: the original queries retain their costs while
+random choices only determine which queries execute.
+-/
+abbrev ofModel [Zero Cost] (M : Model Q Cost) : RandomizeModel Q Cost :=
+  ofModelM
+    { evalQuery := fun q => PMF.pure (M.evalQuery q)
+      cost := M.cost }
+
+end RandomizeModel
+
+/-- A `HasModel` on `Q` induces a handler on `RandomizeQuery Q` in which `Q` queries follow
+their model and draws are free. -/
+noncomputable instance instHasHandlerRandomizeQuery [HasModel Q Cost] [Zero Cost] :
+    Cslib.FreeM.HasHandler (RandomizeQuery Q) .pure :=
+  (RandomizeModel.ofModel (HasModel.model : Model Q Cost)).hasHandler
+
+end Algolean.Algorithms

--- a/AlgoleanTests.lean
+++ b/AlgoleanTests.lean
@@ -8,3 +8,4 @@ public import AlgoleanTests.ModelMWP
 public import AlgoleanTests.NaivePatternSearchExamples
 public import AlgoleanTests.ProgExamples
 public import AlgoleanTests.QueryExamples
+public import AlgoleanTests.RandomSampleExamples

--- a/AlgoleanTests/RandomSampleExamples.lean
+++ b/AlgoleanTests/RandomSampleExamples.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2026 Tanner Duve. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tanner Duve
+-/
+
+module
+
+public import Algolean.Models.RandomSample
+
+/-!
+# Random sampling examples
+
+Sanity checks for the `RandomSample` query language and its `PMF` models. The examples confirm
+that the `model` simp lemmas apply to `free` and `sampleCount` and that the `RandomizeModel`
+constructions compute by `simp`.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+namespace AlgoleanTests.RandomSampleExamples
+
+open Algolean.Algorithms Cslib RandomSample Std.Do
+
+example (dist : PMF ℕ) : (draw dist).evalM (free (Cost := ℕ)) = dist := by
+  simp
+
+example (dist : PMF ℕ) : (draw dist).costM (free (Cost := ℕ)) = pure 0 := by
+  simp
+
+example (dist : PMF ℕ) : (draw dist).costM sampleCount = pure 1 := by
+  simp
+
+example (M : ModelM Q PMF Cost) [Zero Cost] (q : Q α) :
+    (RandomizeQuery.query q).evalM (RandomizeModel.ofModelM M) = M.evalQuery q := by
+  simp
+
+example (M : ModelM Q PMF Cost) [Zero Cost] (dist : PMF α) :
+    (RandomizeQuery.draw dist).evalM (RandomizeModel.ofModelM M) = dist := by
+  simp
+
+example (M : Model Q Cost) [Zero Cost] (q : Q α) :
+    (RandomizeQuery.query q).evalM (RandomizeModel.ofModel M) = PMF.pure (M.evalQuery q) := by
+  simp
+
+/-- One branch stops after one draw while the other performs a second draw. -/
+def branchWithExtraDraw (coin : PMF Bool) (extra : PMF α) : Prog RandomSample Bool := do
+  let b ← draw coin
+  if b then
+    return true
+  else
+    let _ ← draw extra
+    return false
+
+/-- The sample-count distribution is one draw on the `true` branch and two on the `false` branch.
+
+The values drawn from `extra` do not affect the count; only the fact that the second draw occurs
+matters. This theorem concerns random-sample complexity, not standard randomized query runtime.
+-/
+theorem costM_branchWithExtraDraw (coin : PMF Bool) (extra : PMF α) :
+    (branchWithExtraDraw coin extra).costM sampleCount =
+      (fun b => if b then 1 else 2) <$> coin := by
+  simp only [branchWithExtraDraw, draw, Prog.costM_liftBind,
+    model_evalQuery_sample, model_cost]
+  rw [← bind_pure_comp]
+  apply bind_congr
+  intro b
+  cases b <;> simp
+
+-- Almost-sure reasoning through the support interpretation. `mvcgen` discharges the triple that a
+-- drawn value always lies in the distribution's support, using `free`'s handler as the selected
+-- interpretation of the query language.
+set_option mvcgen.warning false in
+example {α : Type} (dist : PMF α) :
+    letI := (free (Cost := ℕ)).hasHandler
+    ⦃⌜True⌝⦄ draw dist ⦃⇓ a => ⌜a ∈ dist.support⌝⦄ := by
+  letI := (free (Cost := ℕ)).hasHandler
+  mvcgen [draw]
+  exact fun a ha => ha
+
+end AlgoleanTests.RandomSampleExamples


### PR DESCRIPTION
This PR adds randomized quicksort in the comparison query model and proves it always returns a sorted permutation of its input. It is stacked on #79, so the compare view includes that PR's commit until it merges. The new material is the last commit, which touches three files.

`randomQuicksort` draws a uniform pivot, partitions the remaining elements by comparison queries against it, and recurses on both sides. `randomQuicksort_spec` proves through `mvcgen` and the support semantics of `PMF` from #79 that every possible output is a sorted permutation. Since quicksort is Las Vegas, this almost-sure statement is its full correctness. The canonical `SortOps` model becomes a `HasModel` instance so the randomized query language over `SortOps` has a default handler for the triples.

The expected runtime analysis with the `2 * n * harmonic n` bound is on a separate branch and will be a follow-up PR.