### PR TITLE
Add randomized quicksort and prove correctness

### DIFF
--- a/Algolean.lean
+++ b/Algolean.lean
@@ -10,6 +10,7 @@ public import Algolean.Algorithms.ListLinearSearch
 public import Algolean.Algorithms.ListOrderedInsert
 public import Algolean.Algorithms.MergeSort
 public import Algolean.Algorithms.NaivePatternSearch
+public import Algolean.Algorithms.RandomQuicksort
 public import Algolean.Algorithms.VecBubbleSort
 public import Algolean.Algorithms.VecSearch
 public import Algolean.Complexity.Basic

--- a/Algolean.lean
+++ b/Algolean.lean
@@ -33,5 +33,6 @@ public import Algolean.Models.ReadOnlyVec
 public import Algolean.Models.ReadWriteVec
 public import Algolean.Models.RobertsonWebb
 public import Algolean.Models.SingleTapeTM
+public import Algolean.Models.UniformSample
 public import Algolean.QueryComposition
 public import Algolean.QueryModel

--- a/Algolean/Algorithms/RandomQuicksort.lean
+++ b/Algolean/Algorithms/RandomQuicksort.lean
@@ -1,0 +1,182 @@
+/-
+Copyright (c) 2026 Tanner Duve (Logical Intelligence). All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tanner Duve
+-/
+module
+
+public import Algolean.Models.ListComparisonSort
+public import Algolean.Models.RandomSample
+public import Mathlib.Probability.Distributions.Uniform
+
+/-!
+# Randomized quicksort of a list
+
+This file defines randomized quicksort in the comparison-query model and proves that it always
+returns a sorted permutation of its input. The proof is by `mvcgen` through the support-based
+weakest-precondition semantics of `PMF`.
+
+## Main definitions
+
+- `randomQuicksort`: randomized quicksort in the `SortOps` query model.
+
+## Main results
+
+- `randomQuicksort_spec`: randomized quicksort returns a sorted permutation.
+-/
+
+@[expose] public section
+
+namespace Algolean
+
+namespace Algorithms
+
+namespace Models
+
+open SortOps Std.Do
+
+/-- Keep the elements of `xs` whose corresponding flag in `bs` is `true`. -/
+def keepFlagged (xs : List α) (bs : List Bool) : List α :=
+  ((xs.zip bs).filter (·.2)).map Prod.fst
+
+theorem keepFlagged_length_le (xs : List α) (bs : List Bool) :
+    (keepFlagged xs bs).length ≤ xs.length :=
+  calc (keepFlagged xs bs).length
+      = ((xs.zip bs).filter (·.2)).length := by rw [keepFlagged, List.length_map]
+    _ ≤ (xs.zip bs).length := List.length_filter_le _ _
+    _ ≤ xs.length := by rw [List.length_zip]; exact Nat.min_le_left _ _
+
+/-- Draw a pivot uniformly, partition the rest by comparison against it, sort each side. -/
+noncomputable def randomQuicksort (l : List α) :
+    Prog (RandomizeQuery (SortOps α)) (List α) :=
+  match l with
+  | [] => pure []
+  | x :: xs => do
+    let r ← RandomizeQuery.draw (PMF.uniformOfFintype (Fin (xs.length + 1)))
+    let pivot := (x :: xs).get r
+    let rest := (x :: xs).eraseIdx r
+    let flags ← rest.mapM (fun y ↦ RandomizeQuery.query (SortOps.cmpLE y pivot))
+    let lt := keepFlagged rest flags
+    let rt := keepFlagged rest (flags.map (!·))
+    let sortedlt ← randomQuicksort lt
+    let sortedrt ← randomQuicksort rt
+    pure (sortedlt ++ [pivot] ++ sortedrt)
+termination_by l.length
+decreasing_by
+  all_goals
+    calc _ ≤ rest.length := keepFlagged_length_le _ _
+      _ = xs.length := by simp [rest, List.length_eraseIdx, r.isLt]
+      _ < (x :: xs).length := by simp
+
+section Correctness
+
+variable {α : Type}
+
+/-- The order relation `x ≤ y` under `[Ord α]`. -/
+local notation:50 a:51 " ≼ " b:51 => Ordering.isLE (compare a b) = true
+
+set_option mvcgen.warning false in
+/-- A comparison query returns whether `y ≤ p` under the `Ord` model. -/
+theorem query_cmpLE_spec [Ord α] (y p : α) :
+    ⦃⌜True⌝⦄
+      (RandomizeQuery.query (SortOps.cmpLE y p) : Prog (RandomizeQuery (SortOps α)) Bool)
+      ⦃⇓ b => ⌜b = (compare y p).isLE⌝⦄ := by
+  mvcgen [RandomizeQuery.query]
+  intro b hb
+  exact (PMF.mem_support_pure_iff ((compare y p).isLE) b).mp hb
+
+set_option mvcgen.warning false in
+/-- Comparing every element of `xs` against `p` yields the flags `xs.map (compare · p |>.isLE)`. -/
+theorem mapM_cmpLE_spec [Ord α] (p : α) (xs : List α) :
+    ⦃⌜True⌝⦄ (xs.mapM (fun y ↦ RandomizeQuery.query (SortOps.cmpLE y p))
+        : Prog (RandomizeQuery (SortOps α)) (List Bool))
+      ⦃⇓ flags => ⌜flags = xs.map (fun y ↦ (compare y p).isLE)⌝⦄ := by
+  induction xs with
+  | nil => mvcgen
+  | cons a as ih =>
+    rw [List.mapM_cons]
+    mvcgen [query_cmpLE_spec, ih]
+    simp_all
+
+/-- Keeping the elements flagged by `xs.map g` is filtering by `g`. -/
+private lemma keepFlagged_map (g : α → Bool) (xs : List α) :
+    keepFlagged xs (xs.map g) = xs.filter g := by
+  unfold keepFlagged
+  induction xs with
+  | nil => rfl
+  | cons a as ih =>
+    simp only [List.map_cons, List.zip_cons_cons, List.filter_cons]
+    cases hg : g a <;> simp_all
+
+/-- Gluing `sl`, `sr` (permutations of the two filter-partitions of `rest`) around `pivot` gives a
+permutation of `pivot :: rest`. -/
+private lemma partition_glue_perm (pivot : α) (g : α → Bool) (rest sl sr : List α)
+    (hslp : sl.Perm (rest.filter g)) (hsrp : sr.Perm (rest.filter (fun y ↦ !g y))) :
+    (sl ++ [pivot] ++ sr).Perm (pivot :: rest) := by
+  have h3 :
+      (rest.filter g ++ [pivot] ++ rest.filter (fun y ↦ !g y)).Perm (pivot :: rest) := by
+    rw [List.append_assoc]
+    exact List.perm_middle.trans ((List.filter_append_perm g rest).cons pivot)
+  exact (((hslp.append_right [pivot]).append_right sr).trans
+    (List.Perm.append_left _ hsrp)).trans h3
+
+/-- The glued list is sorted: each half is sorted and lies on its side of the pivot. -/
+private lemma sorted_glue [Ord α] [Std.TransCmp (compare : α → α → Ordering)]
+    (pivot : α) (rest sl sr : List α)
+    (hslp : sl.Perm (rest.filter (fun y ↦ (compare y pivot).isLE)))
+    (hsls : sl.Pairwise (· ≼ ·))
+    (hsrp : sr.Perm (rest.filter (fun y ↦ !(compare y pivot).isLE)))
+    (hsrs : sr.Pairwise (· ≼ ·)) :
+    (sl ++ [pivot] ++ sr).Pairwise (· ≼ ·) := by
+  have hle : ∀ a ∈ sl, a ≼ pivot :=
+    fun a ha ↦ (List.mem_filter.mp (hslp.mem_iff.mp ha)).2
+  have hge : ∀ b ∈ sr, pivot ≼ b := by
+    intro b hb
+    have h2 := (List.mem_filter.mp (hsrp.mem_iff.mp hb)).2
+    rw [(Std.OrientedCmp.eq_swap : compare pivot b = _)]
+    cases h : compare b pivot <;> simp_all [Ordering.swap, Ordering.isLE]
+  have hcross : ∀ a ∈ sl, ∀ c ∈ pivot :: sr, a ≼ c := by
+    intro a ha c hc
+    cases List.mem_cons.mp hc with
+    | inl h => exact h ▸ hle a ha
+    | inr h => exact Std.TransCmp.isLE_trans (hle a ha) (hge c h)
+  rw [List.append_assoc, List.singleton_append, List.pairwise_append]
+  exact ⟨hsls, List.pairwise_cons.mpr ⟨hge, hsrs⟩, hcross⟩
+
+/-- The glued list is a sorted permutation of `pivot :: rest`. -/
+private lemma quicksort_combine [Ord α] [Std.TransCmp (compare : α → α → Ordering)]
+    (pivot : α) (rest sl sr : List α)
+    (hslp : sl.Perm (rest.filter (fun y ↦ (compare y pivot).isLE)))
+    (hsls : sl.Pairwise (· ≼ ·))
+    (hsrp : sr.Perm (rest.filter (fun y ↦ !(compare y pivot).isLE)))
+    (hsrs : sr.Pairwise (· ≼ ·)) :
+    (sl ++ [pivot] ++ sr).Perm (pivot :: rest) ∧ (sl ++ [pivot] ++ sr).Pairwise (· ≼ ·) :=
+  ⟨partition_glue_perm pivot _ rest sl sr hslp hsrp,
+    sorted_glue pivot rest sl sr hslp hsls hsrp hsrs⟩
+
+set_option mvcgen.warning false in
+/-- Randomized quicksort always returns a sorted permutation of its input. -/
+theorem randomQuicksort_spec [Ord α] [Std.TransCmp (compare : α → α → Ordering)]
+    (l : List α) :
+    ⦃⌜True⌝⦄ randomQuicksort l
+      ⦃⇓ out => ⌜out.Perm l ∧ out.Pairwise (· ≼ ·)⌝⦄ := by
+  fun_induction randomQuicksort l
+  next => mvcgen; exact ⟨.refl _, .nil⟩
+  next x xs ih_lt ih_rt =>
+    mvcgen [RandomizeQuery.draw]
+    intro r _hr
+    mvcgen [mapM_cmpLE_spec, ih_lt, ih_rt]
+    rename_i flags hflags sl hsl sr hsr
+    subst hflags
+    simp only [keepFlagged_map, List.map_map, Function.comp_def] at hsl hsr
+    have hc := quicksort_combine ((x :: xs).get r) ((x :: xs).eraseIdx ↑r) sl sr
+      hsl.1 hsl.2 hsr.1 hsr.2
+    exact ⟨hc.1.trans (List.getElem_cons_eraseIdx_perm r.isLt), hc.2⟩
+
+end Correctness
+
+end Models
+
+end Algorithms
+
+end Algolean

--- a/Algolean/Algorithms/RandomQuicksort.lean
+++ b/Algolean/Algorithms/RandomQuicksort.lean
@@ -6,8 +6,7 @@ Authors: Tanner Duve
 module
 
 public import Algolean.Models.ListComparisonSort
-public import Algolean.Models.RandomSample
-public import Mathlib.Probability.Distributions.Uniform
+public import Algolean.Models.UniformSample
 
 /-!
 # Randomized quicksort of a list
@@ -19,10 +18,13 @@ weakest-precondition semantics of `PMF`.
 ## Main definitions
 
 - `randomQuicksort`: randomized quicksort in the `SortOps` query model.
+- `randomQuicksortModel`: interpret comparisons with a supplied Boolean comparator and
+  pivot draws with a supplied sampling model.
 
 ## Main results
 
 - `randomQuicksort_spec`: randomized quicksort returns a sorted permutation.
+- `randomQuicksort_spec_of_queries`: correctness for any handler satisfying the query contracts.
 -/
 
 @[expose] public section
@@ -33,7 +35,26 @@ namespace Algorithms
 
 namespace Models
 
-open SortOps Std.Do
+open SortOps Std.Do Cslib
+
+/-- Comparison queries and computable finite pivot requests. -/
+abbrev RandomQuicksortOps (α : Type) := fun β => Sum (SortOps α β) (UniformSample β)
+
+/-- Interpret comparisons with `le`, charging one per comparison and using `sampling` for draws. -/
+def randomQuicksortModel [Monad m] (le : α → α → Bool)
+    (sampling : ModelM UniformSample m ℕ) : ModelM (RandomQuicksortOps α) m ℕ :=
+  ModelM.sum
+    { evalQuery := fun q => pure ((sortModelNat le).evalQuery q)
+      cost := (sortModelNat le).cost }
+    sampling
+
+/-- Compare two values through the model's Boolean comparator. -/
+def queryCmpLE (y p : α) : Prog (RandomQuicksortOps α) Bool :=
+  FreeM.lift (.inl (SortOps.cmpLE y p))
+
+/-- Request a pivot index without embedding a probability distribution in the program. -/
+def drawPivot (n : Nat) : Prog (RandomQuicksortOps α) (Fin (n + 1)) :=
+  FreeM.lift (.inr (.fin n))
 
 /-- Keep the elements of `xs` whose corresponding flag in `bs` is `true`. -/
 def keepFlagged (xs : List α) (bs : List Bool) : List α :=
@@ -46,16 +67,19 @@ theorem keepFlagged_length_le (xs : List α) (bs : List Bool) :
     _ ≤ (xs.zip bs).length := List.length_filter_le _ _
     _ ≤ xs.length := by rw [List.length_zip]; exact Nat.min_le_left _ _
 
-/-- Draw a pivot uniformly, partition the rest by comparison against it, sort each side. -/
-noncomputable def randomQuicksort (l : List α) :
-    Prog (RandomizeQuery (SortOps α)) (List α) :=
+/-- Draw a pivot, partition the rest by comparison against it, and sort each side.
+
+Like `mergeSort`, this program obtains its comparator from the model. Using
+`randomQuicksortModel le UniformSample.pmfModel` gives uniform randomized semantics.
+-/
+def randomQuicksort (l : List α) : Prog (RandomQuicksortOps α) (List α) :=
   match l with
   | [] => pure []
   | x :: xs => do
-    let r ← RandomizeQuery.draw (PMF.uniformOfFintype (Fin (xs.length + 1)))
+    let r ← drawPivot xs.length
     let pivot := (x :: xs).get r
     let rest := (x :: xs).eraseIdx r
-    let flags ← rest.mapM (fun y ↦ RandomizeQuery.query (SortOps.cmpLE y pivot))
+    let flags ← rest.mapM (fun y ↦ queryCmpLE y pivot)
     let lt := keepFlagged rest flags
     let rt := keepFlagged rest (flags.map (!·))
     let sortedlt ← randomQuicksort lt
@@ -72,30 +96,31 @@ section Correctness
 
 variable {α : Type}
 
-/-- The order relation `x ≤ y` under `[Ord α]`. -/
-local notation:50 a:51 " ≼ " b:51 => Ordering.isLE (compare a b) = true
+variable (le : α → α → Bool)
 
 set_option mvcgen.warning false in
-/-- A comparison query returns whether `y ≤ p` under the `Ord` model. -/
-theorem query_cmpLE_spec [Ord α] (y p : α) :
+/-- A comparison query returns the supplied comparator's answer. -/
+theorem query_cmpLE_spec (y p : α) :
+    letI := (randomQuicksortModel le UniformSample.pmfModel).hasHandler
     ⦃⌜True⌝⦄
-      (RandomizeQuery.query (SortOps.cmpLE y p) : Prog (RandomizeQuery (SortOps α)) Bool)
-      ⦃⇓ b => ⌜b = (compare y p).isLE⌝⦄ := by
-  mvcgen [RandomizeQuery.query]
+      queryCmpLE y p
+      ⦃⇓b => ⌜b = le y p⌝⦄ := by
+  mvcgen [queryCmpLE]
   intro b hb
-  exact (PMF.mem_support_pure_iff ((compare y p).isLE) b).mp hb
+  exact (PMF.mem_support_pure_iff (le y p) b).mp hb
 
 set_option mvcgen.warning false in
-/-- Comparing every element of `xs` against `p` yields the flags `xs.map (compare · p |>.isLE)`. -/
-theorem mapM_cmpLE_spec [Ord α] (p : α) (xs : List α) :
-    ⦃⌜True⌝⦄ (xs.mapM (fun y ↦ RandomizeQuery.query (SortOps.cmpLE y p))
-        : Prog (RandomizeQuery (SortOps α)) (List Bool))
-      ⦃⇓ flags => ⌜flags = xs.map (fun y ↦ (compare y p).isLE)⌝⦄ := by
+/-- Comparing every element against `p` yields the flags `xs.map (le · p)`. -/
+theorem mapM_cmpLE_spec [FreeM.HasHandler (RandomQuicksortOps α) .pure]
+    (hcmp : ∀ (y p : α), ⦃⌜True⌝⦄ queryCmpLE y p ⦃⇓b => ⌜b = le y p⌝⦄)
+    (p : α) (xs : List α) :
+    ⦃⌜True⌝⦄ (xs.mapM (fun y ↦ queryCmpLE y p))
+      ⦃⇓ flags => ⌜flags = xs.map (fun y ↦ le y p)⌝⦄ := by
   induction xs with
   | nil => mvcgen
   | cons a as ih =>
     rw [List.mapM_cons]
-    mvcgen [query_cmpLE_spec, ih]
+    mvcgen [hcmp, ih]
     simp_all
 
 /-- Keeping the elements flagged by `xs.map g` is filtering by `g`. -/
@@ -121,57 +146,84 @@ private lemma partition_glue_perm (pivot : α) (g : α → Bool) (rest sl sr : L
     (List.Perm.append_left _ hsrp)).trans h3
 
 /-- The glued list is sorted: each half is sorted and lies on its side of the pivot. -/
-private lemma sorted_glue [Ord α] [Std.TransCmp (compare : α → α → Ordering)]
+private lemma sorted_glue [Std.Total (fun a b => le a b = true)]
+    [IsTrans α (fun a b => le a b = true)]
     (pivot : α) (rest sl sr : List α)
-    (hslp : sl.Perm (rest.filter (fun y ↦ (compare y pivot).isLE)))
-    (hsls : sl.Pairwise (· ≼ ·))
-    (hsrp : sr.Perm (rest.filter (fun y ↦ !(compare y pivot).isLE)))
-    (hsrs : sr.Pairwise (· ≼ ·)) :
-    (sl ++ [pivot] ++ sr).Pairwise (· ≼ ·) := by
-  have hle : ∀ a ∈ sl, a ≼ pivot :=
+    (hslp : sl.Perm (rest.filter (fun y ↦ le y pivot)))
+    (hsls : sl.Pairwise (fun a b => le a b = true))
+    (hsrp : sr.Perm (rest.filter (fun y ↦ !le y pivot)))
+    (hsrs : sr.Pairwise (fun a b => le a b = true)) :
+    (sl ++ [pivot] ++ sr).Pairwise (fun a b => le a b = true) := by
+  have hle : ∀ a ∈ sl, le a pivot = true :=
     fun a ha ↦ (List.mem_filter.mp (hslp.mem_iff.mp ha)).2
-  have hge : ∀ b ∈ sr, pivot ≼ b := by
+  have hge : ∀ b ∈ sr, le pivot b = true := by
     intro b hb
     have h2 := (List.mem_filter.mp (hsrp.mem_iff.mp hb)).2
-    rw [(Std.OrientedCmp.eq_swap : compare pivot b = _)]
-    cases h : compare b pivot <;> simp_all [Ordering.swap, Ordering.isLE]
-  have hcross : ∀ a ∈ sl, ∀ c ∈ pivot :: sr, a ≼ c := by
+    have ht := Std.Total.total (r := fun a b => le a b = true) pivot b
+    simp_all
+  have hcross : ∀ a ∈ sl, ∀ c ∈ pivot :: sr, le a c = true := by
     intro a ha c hc
     cases List.mem_cons.mp hc with
     | inl h => exact h ▸ hle a ha
-    | inr h => exact Std.TransCmp.isLE_trans (hle a ha) (hge c h)
+    | inr h =>
+      exact IsTrans.trans (r := fun a b => le a b = true)
+        a pivot c (hle a ha) (hge c h)
   rw [List.append_assoc, List.singleton_append, List.pairwise_append]
   exact ⟨hsls, List.pairwise_cons.mpr ⟨hge, hsrs⟩, hcross⟩
 
 /-- The glued list is a sorted permutation of `pivot :: rest`. -/
-private lemma quicksort_combine [Ord α] [Std.TransCmp (compare : α → α → Ordering)]
+private lemma quicksort_combine [Std.Total (fun a b => le a b = true)]
+    [IsTrans α (fun a b => le a b = true)]
     (pivot : α) (rest sl sr : List α)
-    (hslp : sl.Perm (rest.filter (fun y ↦ (compare y pivot).isLE)))
-    (hsls : sl.Pairwise (· ≼ ·))
-    (hsrp : sr.Perm (rest.filter (fun y ↦ !(compare y pivot).isLE)))
-    (hsrs : sr.Pairwise (· ≼ ·)) :
-    (sl ++ [pivot] ++ sr).Perm (pivot :: rest) ∧ (sl ++ [pivot] ++ sr).Pairwise (· ≼ ·) :=
+    (hslp : sl.Perm (rest.filter (fun y ↦ le y pivot)))
+    (hsls : sl.Pairwise (fun a b => le a b = true))
+    (hsrp : sr.Perm (rest.filter (fun y ↦ !le y pivot)))
+    (hsrs : sr.Pairwise (fun a b => le a b = true)) :
+    (sl ++ [pivot] ++ sr).Perm (pivot :: rest) ∧
+      (sl ++ [pivot] ++ sr).Pairwise (fun a b => le a b = true) :=
   ⟨partition_glue_perm pivot _ rest sl sr hslp hsrp,
-    sorted_glue pivot rest sl sr hslp hsls hsrp hsrs⟩
+    sorted_glue le pivot rest sl sr hslp hsls hsrp hsrs⟩
 
 set_option mvcgen.warning false in
-/-- Randomized quicksort always returns a sorted permutation of its input. -/
-theorem randomQuicksort_spec [Ord α] [Std.TransCmp (compare : α → α → Ordering)]
+/-- Correctness only needs accurate comparisons and a pivot in the requested finite range. -/
+theorem randomQuicksort_spec_of_queries
+    [FreeM.HasHandler (RandomQuicksortOps α) .pure]
+    [Std.Total (fun a b => le a b = true)]
+    [IsTrans α (fun a b => le a b = true)]
+    (hcmp : ∀ (y p : α), ⦃⌜True⌝⦄ queryCmpLE y p ⦃⇓b => ⌜b = le y p⌝⦄)
+    (hdraw : ∀ n, ⦃⌜True⌝⦄ (drawPivot n : Prog (RandomQuicksortOps α) _)
+      ⦃⇓_ => ⌜True⌝⦄)
     (l : List α) :
     ⦃⌜True⌝⦄ randomQuicksort l
-      ⦃⇓ out => ⌜out.Perm l ∧ out.Pairwise (· ≼ ·)⌝⦄ := by
+      ⦃⇓ out => ⌜out.Perm l ∧ out.Pairwise (fun a b => le a b = true)⌝⦄ := by
   fun_induction randomQuicksort l
   next => mvcgen; exact ⟨.refl _, .nil⟩
   next x xs ih_lt ih_rt =>
-    mvcgen [RandomizeQuery.draw]
-    intro r _hr
-    mvcgen [mapM_cmpLE_spec, ih_lt, ih_rt]
+    have hflags := mapM_cmpLE_spec le hcmp
+    mvcgen [hdraw]
+    rename_i r pivot rest
+    dsimp +zetaDelta only
+    mvcgen [hflags, ih_lt, ih_rt]
     rename_i flags hflags sl hsl sr hsr
     subst hflags
     simp only [keepFlagged_map, List.map_map, Function.comp_def] at hsl hsr
-    have hc := quicksort_combine ((x :: xs).get r) ((x :: xs).eraseIdx ↑r) sl sr
+    have hc := quicksort_combine le ((x :: xs).get r) ((x :: xs).eraseIdx ↑r) sl sr
       hsl.1 hsl.2 hsr.1 hsr.2
     exact ⟨hc.1.trans (List.getElem_cons_eraseIdx_perm r.isLt), hc.2⟩
+
+set_option mvcgen.warning false in
+/-- Uniform randomized quicksort returns a sorted permutation under the supplied comparator. -/
+theorem randomQuicksort_spec [Std.Total (fun a b => le a b = true)]
+    [IsTrans α (fun a b => le a b = true)] (l : List α) :
+    letI := (randomQuicksortModel le UniformSample.pmfModel).hasHandler
+    ⦃⌜True⌝⦄ randomQuicksort l
+      ⦃⇓ out => ⌜out.Perm l ∧ out.Pairwise (fun a b => le a b = true)⌝⦄ := by
+  apply @randomQuicksort_spec_of_queries α le
+    (randomQuicksortModel le UniformSample.pmfModel).hasHandler _ _
+    (query_cmpLE_spec le)
+  intro n
+  mvcgen [drawPivot]
+  exact fun _ _ => True.intro
 
 end Correctness
 

--- a/Algolean/Models/ListComparisonSort.lean
+++ b/Algolean/Models/ListComparisonSort.lean
@@ -148,6 +148,9 @@ def sortModelNat {α : Type*}
     | .cmpLE x y => le x y
   cost _ := 1
 
+/-- The canonical `SortOps` model, interpreting `cmpLE x y` as `x ≤ y` under `[Ord α]`. -/
+instance [Ord α] : HasModel (SortOps α) ℕ := ⟨sortModelNat (fun a b => (compare a b).isLE)⟩
+
 end NatModel
 
 section SortStability

--- a/Algolean/Models/ListComparisonSort.lean
+++ b/Algolean/Models/ListComparisonSort.lean
@@ -148,9 +148,6 @@ def sortModelNat {α : Type*}
     | .cmpLE x y => le x y
   cost _ := 1
 
-/-- The canonical `SortOps` model, interpreting `cmpLE x y` as `x ≤ y` under `[Ord α]`. -/
-instance [Ord α] : HasModel (SortOps α) ℕ := ⟨sortModelNat (fun a b => (compare a b).isLE)⟩
-
 end NatModel
 
 section SortStability

--- a/Algolean/Models/UniformSample.lean
+++ b/Algolean/Models/UniformSample.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2026 Tanner Duve (Logical Intelligence). All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tanner Duve
+-/
+module
+
+public import Algolean.Models.RandomSample
+public import Mathlib.Probability.Distributions.Uniform
+
+/-!
+# Computable finite sampling queries
+
+`UniformSample.fin n` requests an index in `Fin (n + 1)`. The query stores only the bound;
+the noncomputable uniform distribution lives in `UniformSample.pmfModel`. Computable interpreters
+can supply their own finite sampler via `UniformSample.model`.
+-/
+
+@[expose] public section
+
+namespace Algolean.Algorithms
+
+/-- A finite sampling request, with a nonempty range by construction. -/
+inductive UniformSample : Type → Type where
+  | fin (n : Nat) : UniformSample (Fin (n + 1))
+
+namespace UniformSample
+
+/-- Interpret finite draws using a supplied sampler and cost per draw. -/
+def model (sample : (n : Nat) → m (Fin (n + 1))) (sampleCost : Cost) :
+    ModelM UniformSample m Cost where
+  evalQuery
+    | .fin n => sample n
+  cost _ := sampleCost
+
+/-- Uniform probabilistic semantics; internal randomness contributes no query cost. -/
+noncomputable def pmfModel [Zero Cost] : ModelM UniformSample PMF Cost :=
+  model (fun n => PMF.uniformOfFintype (Fin (n + 1))) 0
+
+end UniformSample
+
+end Algolean.Algorithms

--- a/AlgoleanTests.lean
+++ b/AlgoleanTests.lean
@@ -8,4 +8,5 @@ public import AlgoleanTests.ModelMWP
 public import AlgoleanTests.NaivePatternSearchExamples
 public import AlgoleanTests.ProgExamples
 public import AlgoleanTests.QueryExamples
+public import AlgoleanTests.RandomQuicksortExamples
 public import AlgoleanTests.RandomSampleExamples

--- a/AlgoleanTests/RandomQuicksortExamples.lean
+++ b/AlgoleanTests/RandomQuicksortExamples.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2026 Tanner Duve (Logical Intelligence). All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tanner Duve
+-/
+module
+
+public import Algolean.Algorithms.RandomQuicksort
+
+/-!
+# Executable randomized quicksort examples
+
+The list interpreter explores every possible sequence of pivot choices. These checks also
+exercise compiled execution: no `noncomputable` definitions are used in the executable models.
+-/
+
+@[expose] public section
+
+namespace AlgoleanTests.RandomQuicksortExamples
+
+open Algolean.Algorithms Algolean.Algorithms.Models
+
+/-- Explore every legal pivot, charging only for comparisons. -/
+def allPivots : ModelM UniformSample List Nat :=
+  UniformSample.model (fun n => List.finRange (n + 1)) 0
+
+/-- Collect the results from every possible pivot sequence. -/
+def outcomes (xs : List α) (le : α → α → Bool) : List (List α) :=
+  (randomQuicksort xs).evalM (randomQuicksortModel le allPivots)
+
+/-- Every pivot sequence must succeed and return the expected list, with at least one outcome. -/
+def checks [BEq α] (xs expected : List α) (le : α → α → Bool) : Bool :=
+  let results := outcomes xs le
+  !results.isEmpty && results.all (· == expected)
+
+#guard checks ([] : List Nat) [] (· ≤ ·)
+#guard checks [7] [7] (· ≤ ·)
+#guard checks [3, 1, 2, 1, 3] [1, 1, 2, 3, 3] (· ≤ ·)
+#guard checks [3, 1, 2, 1, 3] [3, 3, 2, 1, 1] (· ≥ ·)
+#guard checks [4, 4, 4] [4, 4, 4] (· ≤ ·)
+
+/-- A payload type deliberately lacking an `Ord` instance. -/
+structure Entry where
+  key : Nat
+  payload : String
+  deriving BEq, Repr
+
+#guard checks ([⟨2, "b"⟩, ⟨1, "a"⟩, ⟨3, "c"⟩] : List Entry)
+    [⟨3, "c"⟩, ⟨2, "b"⟩, ⟨1, "a"⟩] (fun a b => a.key ≥ b.key)
+
+-- The middle pivot takes two comparisons; either end pivot takes three. Finite draws are free.
+#guard (randomQuicksort [1, 2, 3]).costM (randomQuicksortModel (· ≤ ·) allPivots) ==
+  [3, 3, 2, 3, 3]
+#guard (randomQuicksort [7]).costM (randomQuicksortModel (· ≤ ·) allPivots) == [0]
+
+end AlgoleanTests.RandomQuicksortExamples


### PR DESCRIPTION
This PR adds randomized quicksort in the comparison query model and proves it always returns a sorted permutation of its input. It is stacked on #81 and targets that branch, so the diff is exactly the new material. Merge #81 first, then retarget this to main.

`randomQuicksort` draws a uniform pivot, partitions the remaining elements by comparison queries against it, and recurses on both sides. `randomQuicksort_spec` proves through `mvcgen` and the support semantics of `PMF` from #81 that every possible output is a sorted permutation. Since quicksort is Las Vegas, this almost-sure statement is its full correctness. The canonical `SortOps` model becomes a `HasModel` instance so the randomized query language over `SortOps` has a default handler for the triples.

The expected runtime analysis with the `2 * n * harmonic n` bound is on a separate branch and will be a follow-up PR.